### PR TITLE
Fix line chart initialization

### DIFF
--- a/tech-farming-frontend/src/app/dashboard/components/line-chart.component.ts
+++ b/tech-farming-frontend/src/app/dashboard/components/line-chart.component.ts
@@ -19,12 +19,7 @@ Chart.register(...registerables);
   imports: [CommonModule, FormsModule],
   template: `
     <div class="relative w-full h-full">
-      <!-- El <canvas> solo se muestra cuando chartReady = true -->
-      <canvas
-        #chartCanvas
-        class="w-full h-full"
-        *ngIf="chartReady"
-      ></canvas>
+      <canvas #chartCanvas class="w-full h-full"></canvas>
 
       <!-- Spinner mientras el gráfico no está listo -->
       <div *ngIf="!chartReady" class="absolute inset-0 flex items-center justify-center bg-base-200">
@@ -220,6 +215,12 @@ export class LineChartComponent implements OnInit, AfterViewInit {
     this.labels = nuevasLabels;
     this.data = nuevosValores;
     this.variable = nuevaVariable;
+
+    // Si el gráfico aún no se ha inicializado, créalo ahora
+    if (!this.chartInstance) {
+      this.createChart();
+      return;
+    }
 
     // Reconfigurar dataset
     let borderColor = '#2B6B4A';


### PR DESCRIPTION
## Summary
- always render canvas for the dashboard line chart
- guard against chart access before initialization

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68425fb18a40832a80f3b0352638fbf8