### PR TITLE
Update dashboard filter behavior

### DIFF
--- a/tech-farming-frontend/src/app/dashboard/dashboard.component.ts
+++ b/tech-farming-frontend/src/app/dashboard/dashboard.component.ts
@@ -69,6 +69,7 @@ import { Invernadero, Zona, Sensor, Alerta } from '../models';
                 [disabled]="!filtros.invernaderoId"
                 [ngClass]="{ 'opacity-50 cursor-not-allowed': !filtros.invernaderoId }"
                 aria-label="Selecciona Zona"
+                (change)="onZonaChange()"
               >
                 <option [ngValue]="null" disabled selected>— Zona —</option>
                 <option *ngFor="let z of zonasMap[filtros.invernaderoId!]" [ngValue]="z.id">
@@ -77,14 +78,6 @@ import { Invernadero, Zona, Sensor, Alerta } from '../models';
               </select>
             </div>
 
-            <!-- Botón Aplicar Filtros -->
-            <button
-              class="btn btn-success btn-sm mt-2 sm:mt-0"
-              (click)="aplicarFiltros()"
-              aria-label="Aplicar filtros generales"
-            >
-              Aplicar
-            </button>
           </div>
         </div>
       </header>
@@ -465,11 +458,12 @@ export class DashboardPageComponent implements OnInit, AfterViewInit {
     this.cargarAlertas();
   }
 
-  aplicarFiltros(): void {
+  onZonaChange(): void {
     this.cargarZonasYsensores();
     this.cargarAlertas();
     this.cambiarIntervalo(this.intervaloSeleccionado);
   }
+
 
   // ───────── CAMBIAR VARIABLE ─────────
   onVariableChange(): void {


### PR DESCRIPTION
## Summary
- trigger zone change on select instead of Apply button
- remove obsolete Apply button from dashboard template
- refresh data when zone changes

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68426aefc900832a8ec8a4bfa00311de