### PR TITLE
Enable zone reset option

### DIFF
--- a/tech-farming-frontend/src/app/dashboard/dashboard.component.ts
+++ b/tech-farming-frontend/src/app/dashboard/dashboard.component.ts
@@ -66,11 +66,12 @@ import { Invernadero, Zona, Sensor, Alerta } from '../models';
                 id="zonaSelect"
                 class="select select-bordered select-sm w-full"
                 [(ngModel)]="filtros.zonaId"
+                (change)="onZonaChange()"
                 [disabled]="!filtros.invernaderoId"
                 [ngClass]="{ 'opacity-50 cursor-not-allowed': !filtros.invernaderoId }"
                 aria-label="Selecciona Zona"
               >
-                <option [ngValue]="null" disabled selected>— Zona —</option>
+                <option [ngValue]="null">— Zona —</option>
                 <option *ngFor="let z of zonasMap[filtros.invernaderoId!]" [ngValue]="z.id">
                   {{ z.nombre }}
                 </option>
@@ -463,6 +464,11 @@ export class DashboardPageComponent implements OnInit, AfterViewInit {
     this.filtros.zonaId = null;
     this.cargarZonasYsensores();
     this.cargarAlertas();
+  }
+
+  onZonaChange(): void {
+    this.cargarAlertas();
+    this.cambiarIntervalo(this.intervaloSeleccionado);
   }
 
   aplicarFiltros(): void {


### PR DESCRIPTION
## Summary
- allow clearing the zone filter on the dashboard

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68426af0e02c832a9a17abd33458f93f