### PR TITLE
Fix default selection logic in dashboard

### DIFF
--- a/tech-farming-frontend/src/app/dashboard/dashboard.component.ts
+++ b/tech-farming-frontend/src/app/dashboard/dashboard.component.ts
@@ -540,7 +540,13 @@ export class DashboardPageComponent implements OnInit, AfterViewInit {
 
   private cargarInvernaderos() {
     this.dashSvc.getInvernaderos().subscribe({
-      next: (list) => (this.invernaderos = list),
+      next: (list) => {
+        this.invernaderos = list;
+        if (list.length) {
+          this.filtros.invernaderoId = list[0].id;
+          this.onInvernaderoChange();
+        }
+      },
       error: () => this.notify.error('Error al cargar invernaderos')
     });
   }
@@ -558,6 +564,11 @@ export class DashboardPageComponent implements OnInit, AfterViewInit {
         this.sensoresDisponibles = sens.map((s) => s.nombre);
         this.totalSensores = sens.length;
         this.sensoresActivos = sens.filter((s) => s.estado === 'Activo').length;
+
+        this.sensorSeleccionado = this.sensoresDisponibles[0] ?? null;
+        if (this.sensorSeleccionado) {
+          this.cambiarIntervalo(this.intervaloSeleccionado);
+        }
 
         const paramMap = new Map<string, string | undefined>();
         sens.forEach((s) =>


### PR DESCRIPTION
## Summary
- auto-select first greenhouse in `cargarInvernaderos`
- set default sensor and refresh graph when sensors are loaded

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684270730b70832ab2f491655e7f31d8