### PR TITLE
Improve splash screen animation

### DIFF
--- a/tech-farming-frontend/src/app/core/components/splash/splash.component.css
+++ b/tech-farming-frontend/src/app/core/components/splash/splash.component.css
@@ -64,12 +64,22 @@
     100% { content: '.'; }
   }
   
-  .dots-animation::after {
+.dots-animation::after {
     content: '.';
     animation: blinkDots 1.5s steps(3, end) infinite;
     position: absolute;
     top: 0;
     right: -1.5ch;
     width: 2ch;
-    text-align: left;
-  }
+  text-align: left;
+}
+
+/* Fade out when closing */
+@keyframes splashFadeOut {
+  from { opacity: 1; transform: scale(1); }
+  to   { opacity: 0; transform: scale(0.9); }
+}
+
+.fade-out {
+  animation: splashFadeOut 0.5s ease-in-out forwards;
+}

--- a/tech-farming-frontend/src/app/core/components/splash/splash.component.html
+++ b/tech-farming-frontend/src/app/core/components/splash/splash.component.html
@@ -1,4 +1,4 @@
-<div class="fixed inset-0 bg-white z-[99999] flex items-center justify-center">
+<div class="fixed inset-0 bg-white z-[99999] flex items-center justify-center" [ngClass]="{'fade-out': fadeOut}">
     <!-- Flare animación de fondo -->
     <div class="absolute inset-0 z-[99998] pointer-events-none flare-animation"></div>
   
@@ -7,11 +7,11 @@
   
       <!-- Branding con imagen -->
       <div class="flex items-center gap-4 flex-wrap justify-center text-center">
-        <img src="assets/img/hoja-logo.png" 
+        <img src="assets/img/hoja-logo.png"
              alt="Logo Tech Farming"
-             class="w-[4rem] sm:w-[5rem] md:w-[6rem] h-auto rounded-full drop-shadow-xl saturate-[1.2] animate-splashIcon">
+             class="w-[6rem] sm:w-[8rem] md:w-[10rem] h-auto rounded-full drop-shadow-xl saturate-[1.2] animate-splashIcon">
   
-        <h1 class="text-[2rem] sm:text-[2.75rem] md:text-[4rem] font-extrabold text-green-800 tracking-tight animate-splashText drop-shadow-md">
+        <h1 class="text-[3rem] sm:text-[4rem] md:text-[5rem] font-extrabold text-green-800 tracking-tight animate-splashText drop-shadow-md">
           Tech Farming
         </h1>
       </div>

--- a/tech-farming-frontend/src/app/core/components/splash/splash.component.ts
+++ b/tech-farming-frontend/src/app/core/components/splash/splash.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { AppLogoComponent } from "../app-logo.component";
 
 @Component({
@@ -8,4 +8,6 @@ import { AppLogoComponent } from "../app-logo.component";
   styleUrls: ['./splash.component.css'],
   imports: [AppLogoComponent],
 })
-export class SplashComponent {}
+export class SplashComponent {
+  @Input() fadeOut = false;
+}

--- a/tech-farming-frontend/src/app/layout/layout.component.html
+++ b/tech-farming-frontend/src/app/layout/layout.component.html
@@ -1,7 +1,7 @@
 <!-- layout.component.html -->
 
 <!-- Splash -->
-<app-splash *ngIf="showSplash" class="fixed inset-0 z-[9999]"></app-splash>
+<app-splash *ngIf="showSplash" [fadeOut]="hideSplash" class="fixed inset-0 z-[9999]"></app-splash>
 
 <!-- Contenido principal (se oculta mientras el splash está activo) -->
 <ng-container *ngIf="!showSplash">

--- a/tech-farming-frontend/src/app/layout/layout.component.ts
+++ b/tech-farming-frontend/src/app/layout/layout.component.ts
@@ -24,10 +24,13 @@ export class LayoutComponent {
   ) { }
 
   showSplash = true;
+  hideSplash = false;
 
   ngOnInit() {
     setTimeout(() => {
-      this.showSplash = false;
+      this.hideSplash = true;
+      setTimeout(() => {
+        this.showSplash = false;
 
       this.route.queryParams.subscribe(params => {
         const vieneDeInvitacion = params['invitacion'] === 'true';
@@ -36,8 +39,9 @@ export class LayoutComponent {
           this.router.navigateByUrl('/dashboard');
         }
       });
+      }, 500);
 
 
-    }, 2000);
+    }, 4000);
   }
 }


### PR DESCRIPTION
## Summary
- extend splash screen duration with a fade-out effect
- enlarge logo and heading size on splash
- allow LayoutComponent to control splash fade state

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6843b9f5ee00832a8fa6f1ae43b5f74f