### PR TITLE
Fix chart cleanup on dashboard

### DIFF
--- a/tech-farming-frontend/src/app/dashboard/components/line-chart.component.ts
+++ b/tech-farming-frontend/src/app/dashboard/components/line-chart.component.ts
@@ -4,7 +4,8 @@ import {
   OnInit,
   AfterViewInit,
   ViewChild,
-  ElementRef
+  ElementRef,
+  OnDestroy
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -28,7 +29,7 @@ Chart.register(...registerables);
     </div>
   `,
 })
-export class LineChartComponent implements OnInit, AfterViewInit {
+export class LineChartComponent implements OnInit, AfterViewInit, OnDestroy {
   @Input() labels!: string[];    // Por ejemplo: ['00:00','01:00',...]
   @Input() data!: number[];      // Por ejemplo: [22,24,23,...]
   @Input() variable!: 'Temperatura' | 'Humedad' | 'Nitrógeno';
@@ -240,5 +241,11 @@ export class LineChartComponent implements OnInit, AfterViewInit {
     this.chartInstance.data.datasets[0].borderColor = borderColor;
     this.chartInstance.data.datasets[0].backgroundColor = backgroundColor;
     this.chartInstance.update();
+  }
+
+  ngOnDestroy(): void {
+    if (this.chartInstance) {
+      this.chartInstance.destroy();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- include OnDestroy in dashboard line chart component
- destroy Chart.js instance when leaving dashboard

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68452ea3ff6c832a9c7f3be02703b9b2