### PR TITLE
Add loading spinner for view invernadero

### DIFF
--- a/tech-farming-frontend/src/app/invernaderos/components/view-invernadero.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/view-invernadero.component.ts
@@ -16,7 +16,8 @@ import {
   import { CommonModule } from '@angular/common';
   import { FormsModule } from '@angular/forms';
   import { HttpClientModule, HttpClient, HttpParams } from '@angular/common/http';
-  import { forkJoin } from 'rxjs';
+import { forkJoin, of } from 'rxjs';
+import { catchError, finalize, tap } from 'rxjs/operators';
   
   import { InvernaderoService } from '../invernaderos.service';
   import { AlertService } from '../../alertas/alertas.service';
@@ -75,6 +76,7 @@ import {
     standalone: true,
     imports: [CommonModule, FormsModule, HttpClientModule],
     template: `
+      <div *ngIf="!isLoading; else loadingTpl">
       <section
         #snapContainer
         class="w-full max-w-[70vw] max-h-[70vh] snap-container bg-base-100 text-base-content relative"
@@ -956,6 +958,15 @@ import {
             </svg>
         </button>
         </nav>
+      </div>
+      <ng-template #loadingTpl>
+        <div class="p-8 text-center">
+          <svg class="animate-spin w-8 h-8 text-success mx-auto" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"></path>
+          </svg>
+        </div>
+      </ng-template>
     `,
     styles: [
       `
@@ -1087,7 +1098,9 @@ import {
     public alertasPageIndex = 1;
     public alertasPageSize = 10;
     public totalPagAlertas = 1;
-  
+
+    public isLoading = true;
+
     public isLoadingZonas = false;
     public isLoadingSensores = false;
     public isLoadingAlertas = false;
@@ -1217,54 +1230,56 @@ import {
     }
   
     private inicializarDatos() {
-      this.cargarDetalleYResumenConAlertasActivas();
-      this.recargarSensores();
-      this.recargarAlertas();
+      this.isLoading = true;
+      forkJoin([
+        this.cargarDetalleYResumenConAlertasActivas(),
+        this.recargarSensores(true),
+        this.recargarAlertas(true)
+      ])
+        .pipe(finalize(() => (this.isLoading = false)))
+        .subscribe({
+          error: (err) => console.error('Error inicializando datos:', err)
+        });
     }
   
-    private cargarDetalleYResumenConAlertasActivas() {
-      forkJoin({
-        detalle: this.invSvc.getInvernaderoDetalle(this.invernaderoId),
-        resumen: this.invSvc.obtenerResumenEliminacion(this.invernaderoId),
-        activas: this.invSvc.getAlertasActivasCount(this.invernaderoId)
-      }).subscribe({
-        next: ({
-          detalle,
-          resumen,
-          activas
-        }: {
-          detalle: any;
-          resumen: { zonasCount: number; sensoresCount: number; alertasCount: number };
-          activas: { alertasActivasCount: number };
-        }) => {
-          this.invernaderoDetalle = {
-            id: detalle.id,
-            nombre: detalle.nombre,
-            descripcion: detalle.descripcion,
-            creado_en: detalle.creado_en,
-            zonas: detalle.zonas.map((z: any) => ({
-              id: z.id,
-              nombre: z.nombre,
-              descripcion: z.descripcion,
-              activo: z.activo,
-              creado_en: z.creado_en,
-              sensores_count: Array.isArray(z.sensores) ? z.sensores.length : 0,
-              sensores: z.sensores
-            }))
-          };
   
-          this.resumenDelete = {
-            zonasCount: resumen.zonasCount,
-            sensoresCount: resumen.sensoresCount,
-            alertasCount: resumen.alertasCount,
-            alertasActivasCount: activas.alertasActivasCount
-          };
-          this.recargarZonas();
-        },
-        error: (err) => console.error('Error cargando detalle/summary/activas:', err)
-      });
-    }
-  
+  private cargarDetalleYResumenConAlertasActivas() {
+    return forkJoin({
+      detalle: this.invSvc.getInvernaderoDetalle(this.invernaderoId),
+      resumen: this.invSvc.obtenerResumenEliminacion(this.invernaderoId),
+      activas: this.invSvc.getAlertasActivasCount(this.invernaderoId)
+    }).pipe(
+      tap(({ detalle, resumen, activas }) => {
+        this.invernaderoDetalle = {
+          id: detalle.id,
+          nombre: detalle.nombre,
+          descripcion: detalle.descripcion,
+          creado_en: detalle.creado_en,
+          zonas: detalle.zonas.map((z: any) => ({
+            id: z.id,
+            nombre: z.nombre,
+            descripcion: z.descripcion,
+            activo: z.activo,
+            creado_en: z.creado_en,
+            sensores_count: Array.isArray(z.sensores) ? z.sensores.length : 0,
+            sensores: z.sensores
+          }))
+        } as InvernaderoDetalle;
+
+        this.resumenDelete = {
+          zonasCount: resumen.zonasCount,
+          sensoresCount: resumen.sensoresCount,
+          alertasCount: resumen.alertasCount,
+          alertasActivasCount: activas.alertasActivasCount
+        };
+        this.recargarZonas();
+      }),
+      catchError((err) => {
+        console.error('Error cargando detalle/summary/activas:', err);
+        return of(null);
+      })
+    );
+  }
     recargarZonas() {
       if (!this.invernaderoDetalle) return;
       this.isLoadingZonas = true;
@@ -1279,7 +1294,7 @@ import {
       this.isLoadingZonas = false;
     }
   
-    recargarSensores() {
+    recargarSensores(asObservable = false) {
       this.isLoadingSensores = true;
       const params = new HttpParams()
         .set('invernadero', this.invernaderoId.toString())
@@ -1288,23 +1303,25 @@ import {
         .set('search', this.filtroSensores.nombre || '')
         .set('estado', this.filtroSensores.estado || '');
   
-      this.http
+      const req$ = this.http
         .get<{ data: SensorDetalle[]; total: number }>(`http://localhost:5000/api/sensores`, { params })
-        .subscribe({
-          next: (resp) => {
+        .pipe(
+          tap((resp) => {
             this.sensoresPage.data = resp.data;
             this.sensoresPage.total = resp.total;
             this.totalPagSensores = Math.ceil(resp.total / this.sensoresPageSize);
-            this.isLoadingSensores = false;
-          },
-          error: (err) => {
+          }),
+          catchError((err) => {
             console.error('Error cargando sensores:', err);
-            this.isLoadingSensores = false;
-          }
-        });
+            return of({ data: [], total: 0 });
+          }),
+          finalize(() => (this.isLoadingSensores = false))
+        );
+
+      return asObservable ? req$ : req$.subscribe();
     }
   
-    recargarAlertas() {
+    recargarAlertas(asObservable = false) {
       this.isLoadingAlertas = true;
       const params = new HttpParams()
         .set('invernadero_id', this.invernaderoId.toString())
@@ -1312,23 +1329,25 @@ import {
         .set('page', this.alertasPageIndex.toString())
         .set('perPage', this.alertasPageSize.toString());
   
-      this.http
+      const req$ = this.http
         .get<{
           data: AlertaResumen[];
           pagination: { total: number; pages: number; per_page: number; page: number };
         }>(`http://localhost:5000/api/alertas`, { params })
-        .subscribe({
-          next: (resp) => {
+        .pipe(
+          tap((resp) => {
             this.alertasPage.data = resp.data;
             this.alertasPage.total = resp.pagination.total;
             this.totalPagAlertas = resp.pagination.pages;
-            this.isLoadingAlertas = false;
-          },
-          error: (err) => {
+          }),
+          catchError((err) => {
             console.error('Error cargando alertas:', err);
-            this.isLoadingAlertas = false;
-          }
-        });
+            return of({ data: [], pagination: { total: 0, pages: 0, per_page: 0, page: 0 } });
+          }),
+          finalize(() => (this.isLoadingAlertas = false))
+        );
+
+      return asObservable ? req$ : req$.subscribe();
     }
   
     resolverAlerta(alertaId: number) {


### PR DESCRIPTION
## Summary
- show spinner while fetching invernadero data
- combine data loading observables in `inicializarDatos`
- return observables from `recargarSensores` and `recargarAlertas`

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68465f15f34c832abf4b883b72e7b5f7