### PR TITLE
Refactor alert tables to DaisyUI

### DIFF
--- a/tech-farming-frontend/src/app/alertas/alertas.service.ts
+++ b/tech-farming-frontend/src/app/alertas/alertas.service.ts
@@ -6,6 +6,8 @@ export interface Alerta {
   id: number;
   sensor_parametro_id: number;
   sensor_nombre: string;
+  /** Nombre del tipo de parámetro asociado al sensor */
+  tipo_parametro?: string;
   tipo: string;
   nivel: 'Advertencia' | 'Crítico';
   valor_detectado: number;

--- a/tech-farming-frontend/src/app/alertas/components/alertas-activas.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/alertas-activas.component.ts
@@ -1,73 +1,54 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatTableModule } from '@angular/material/table';
-import { MatButtonModule } from '@angular/material/button';
 import { Alerta } from '../../models/index';
 
 @Component({
   selector: 'app-active-alerts',
   standalone: true,
-  imports: [CommonModule, MatTableModule, MatButtonModule],
+  imports: [CommonModule],
   template: `
-    <table mat-table [dataSource]="alertas" class="w-full mat-elevation-z1">
-      <!-- Fecha -->
-      <ng-container matColumnDef="fecha_hora">
-        <th mat-header-cell *matHeaderCellDef><span class="text-base-content font-bold">Fecha</span></th>
-        <td mat-cell *matCellDef="let a">{{ a.fecha_hora | date:'short' }}</td>
-      </ng-container>
-
-      <!-- Sensor -->
-      <ng-container matColumnDef="sensor_nombre">
-        <th mat-header-cell *matHeaderCellDef><span class="text-base-content font-bold">Sensor</span></th>
-        <td mat-cell *matCellDef="let a" >{{ a.sensor_nombre || '-' }}</td>
-      </ng-container>
-
-      <!-- Tipo de Parámetro -->
-      <ng-container matColumnDef="tipo_parametro">
-        <th mat-header-cell *matHeaderCellDef><span class="text-base-content font-bold">Parámetro</span></th>
-        <td mat-cell *matCellDef="let a">{{ a.tipo_parametro || '-' }}</td>
-      </ng-container>
-      
-      <!-- Nivel -->
-      <ng-container matColumnDef="nivel">
-        <th mat-header-cell *matHeaderCellDef><span class="text-base-content font-bold">Nivel</span></th>
-        <td mat-cell *matCellDef="let a">
-          <span
-            class="badge badge-md"
-            [ngClass]="{
-              'badge-warning': a.nivel === 'Advertencia',
-              'badge-error': a.nivel === 'Crítico'
-            }"
-          >
-            {{ a.nivel }}
-          </span>
-        </td>
-      </ng-container>
-
-      <!-- Mensaje -->
-      <ng-container matColumnDef="mensaje">
-        <th mat-header-cell *matHeaderCellDef><span class="text-base-content font-bold">Mensaje</span></th>
-        <td mat-cell *matCellDef="let a">{{ a.mensaje }}</td>
-      </ng-container>
-
-      <!-- Acciones -->
-      <ng-container matColumnDef="acciones">
-        <th mat-header-cell *matHeaderCellDef><span class="text-base-content font-bold">Acciones</span></th>
-        <td mat-cell *matCellDef="let a">
-          <button
-            class="btn btn-outline btn-sm"
-            (click)="resolver.emit(a)"
-            [disabled]="resolviendoId === a.id">
-            <ng-container *ngIf="resolviendoId === a.id; else texto">
-              <span class="loading loading-spinner loading-sm"></span>
-            </ng-container>
-            <ng-template #texto>Resolver</ng-template>
-          </button>
-        </td>
-      </ng-container>
-
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    <table class="table w-full">
+      <thead>
+        <tr class="text-base-content font-bold">
+          <th>Fecha</th>
+          <th>Sensor</th>
+          <th>Parámetro</th>
+          <th>Nivel</th>
+          <th>Mensaje</th>
+          <th class="text-right">Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let a of alertas">
+          <td>{{ a.fecha_hora | date:'short' }}</td>
+          <td>{{ a.sensor_nombre || '-' }}</td>
+          <td>{{ a.tipo_parametro || '-' }}</td>
+          <td>
+            <span
+              class="badge badge-md"
+              [ngClass]="{
+                'badge-warning': a.nivel === 'Advertencia',
+                'badge-error': a.nivel === 'Crítico'
+              }"
+            >
+              {{ a.nivel }}
+            </span>
+          </td>
+          <td>{{ a.mensaje }}</td>
+          <td class="text-right">
+            <button
+              class="btn btn-outline btn-sm"
+              (click)="resolver.emit(a)"
+              [disabled]="resolviendoId === a.id"
+            >
+              <ng-container *ngIf="resolviendoId === a.id; else texto">
+                <span class="loading loading-spinner loading-sm"></span>
+              </ng-container>
+              <ng-template #texto>Resolver</ng-template>
+            </button>
+          </td>
+        </tr>
+      </tbody>
     </table>
   `
 })
@@ -75,5 +56,4 @@ export class ActiveAlertsComponent {
   @Input() alertas: Alerta[] = [];
   @Input() resolviendoId: number | null = null;
   @Output() resolver = new EventEmitter<Alerta>();
-  displayedColumns: string[] = ['fecha_hora', 'tipo_parametro', 'sensor_nombre', 'nivel', 'mensaje', 'acciones'];
 }

--- a/tech-farming-frontend/src/app/alertas/components/alertas-historial.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/alertas-historial.component.ts
@@ -1,66 +1,46 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatTableModule } from '@angular/material/table';
 import { Alerta } from '../../models/index';
 
 @Component({
   selector: 'app-alerts-history',
   standalone: true,
-  imports: [CommonModule, MatTableModule],
+  imports: [CommonModule],
   template: `
-    <table mat-table [dataSource]="alertas" class="w-full mat-elevation-z1">
-      <!-- Fecha -->
-      <ng-container matColumnDef="fecha_hora">
-        <th mat-header-cell *matHeaderCellDef><span class="text-base-content font-bold">Fecha</span></th>
-        <td mat-cell *matCellDef="let a">{{ a.fecha_hora | date:'short' }}</td>
-      </ng-container>
-
-      <!-- Sensor -->
-      <ng-container matColumnDef="sensor_nombre">
-        <th mat-header-cell *matHeaderCellDef><span class="text-base-content font-bold">Sensor</span></th>
-        <td mat-cell *matCellDef="let a">{{ a.sensor_nombre || '-' }}</td>
-      </ng-container>
-
-      <!-- Tipo de Parámetro -->
-      <ng-container matColumnDef="tipo_parametro">
-        <th mat-header-cell *matHeaderCellDef><span class="text-base-content font-bold">Parámetro</span></th>
-        <td mat-cell *matCellDef="let a">{{ a.tipo_parametro || '-' }}</td>
-      </ng-container>
-
-      <!-- Nivel -->
-      <ng-container matColumnDef="nivel">
-        <th mat-header-cell *matHeaderCellDef><span class="text-base-content font-bold">Nivel</span></th>
-        <td mat-cell *matCellDef="let a">
-          <span
-            class="badge badge-md"
-            [ngClass]="{
-              'badge-warning': a.nivel === 'Advertencia',
-              'badge-error': a.nivel === 'Crítico'
-            }"
-          >
-            {{ a.nivel }}
-          </span>
-        </td>
-      </ng-container>
-
-      <!-- Mensaje -->
-      <ng-container matColumnDef="mensaje">
-        <th mat-header-cell *matHeaderCellDef><span class="text-base-content font-bold">Mensaje</span></th>
-        <td mat-cell *matCellDef="let a">{{ a.mensaje }}</td>
-      </ng-container>
-
-      <!-- Resuelta por -->
-      <ng-container matColumnDef="resuelta_por">
-        <th mat-header-cell *matHeaderCellDef><span class="text-base-content font-bold">Resuelta por</span></th>
-        <td mat-cell *matCellDef="let a">{{ a.resuelta_por }}</td>
-      </ng-container>
-
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    <table class="table w-full">
+      <thead>
+        <tr class="text-base-content font-bold">
+          <th>Fecha</th>
+          <th>Sensor</th>
+          <th>Parámetro</th>
+          <th>Nivel</th>
+          <th>Mensaje</th>
+          <th>Resuelta por</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let a of alertas">
+          <td>{{ a.fecha_hora | date:'short' }}</td>
+          <td>{{ a.sensor_nombre || '-' }}</td>
+          <td>{{ a.tipo_parametro || '-' }}</td>
+          <td>
+            <span
+              class="badge badge-md"
+              [ngClass]="{
+                'badge-warning': a.nivel === 'Advertencia',
+                'badge-error': a.nivel === 'Crítico'
+              }"
+            >
+              {{ a.nivel }}
+            </span>
+          </td>
+          <td>{{ a.mensaje }}</td>
+          <td>{{ a.resuelta_por }}</td>
+        </tr>
+      </tbody>
     </table>
   `
 })
 export class AlertsHistoryComponent {
   @Input() alertas: Alerta[] = [];
-  displayedColumns: string[] = ['fecha_hora', 'tipo_parametro', 'sensor_nombre', 'nivel', 'mensaje', 'resuelta_por'];
 }

--- a/tech-farming-frontend/src/app/models/index.ts
+++ b/tech-farming-frontend/src/app/models/index.ts
@@ -105,6 +105,8 @@ export interface Alerta {
   id: number;
   sensor_parametro_id: number;
   sensor_nombre: string;
+  /** Nombre del tipo de parámetro asociado al sensor */
+  tipo_parametro?: string;
   tipo: string;
   nivel: 'Advertencia' | 'Crítico';
   valor_detectado: number;


### PR DESCRIPTION
## Summary
- update ActiveAlertsComponent and AlertsHistoryComponent to drop Angular Material tables
- implement DaisyUI table structure via `<thead>` and `<tbody>`
- generate table rows using `*ngFor`
- add missing `tipo_parametro` field in `Alerta` interface

## Testing
- `npm test` *(fails: No binary for Chrome browser)*


------
https://chatgpt.com/codex/tasks/task_e_68465e42ba34832aaa47727043e4a5a6