### PR TITLE
Add skeleton loaders for zones and alerts

### DIFF
--- a/tech-farming-frontend/src/app/invernaderos/components/invernadero-card-list.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/invernadero-card-list.component.ts
@@ -12,31 +12,67 @@ import { Invernadero } from '../models/invernadero.model';
     <!-- Tarjetas móviles -->
     <div class="grid gap-4 md:hidden">
       <ng-container *ngIf="!loading; else cardSkeletons">
-        <div *ngFor="let inv of pagedInvernaderos" class="card p-4 space-y-2 bg-white rounded-lg shadow">
-          <h2 class="font-bold text-lg">{{ inv.nombre }}</h2>
-          <p><strong>Sensores Activos:</strong> {{ inv.sensoresActivos ?? 0 }}</p>
-          <p>
-            <strong>Estado:</strong>
-            <span [ngClass]="{
-              'badge badge-success': inv.estado === 'Activo',
-              'badge badge-warning': inv.estado === 'Inactivo',
-              'badge badge-error': inv.estado === 'Mantenimiento'
-            }">{{ inv.estado }}</span>
-          </p>
-          <p><strong>Creado:</strong> {{ inv.creado_en | date:'short' }}</p>
-          <div class="flex gap-2 mt-2">
-            <button class="btn btn-sm btn-outline" (click)="view(inv)">👁️ Ver</button>
-            <button class="btn btn-sm btn-outline" (click)="edit(inv)">✏️ Editar</button>
-            <button class="btn btn-sm btn-error text-white" (click)="delete(inv)">🗑️ Eliminar</button>
+        <div *ngFor="let inv of pagedInvernaderos" class="card bg-base-100 shadow-lg p-6">
+          <!-- Header -->
+          <div class="flex justify-between items-center mb-2">
+            <h3 class="text-lg font-semibold">{{ inv.nombre }}</h3>
+            <span
+              class="badge badge-sm"
+              [ngClass]="{
+                'badge-success': inv.estado === 'Activo',
+                'badge-warning': inv.estado === 'Inactivo',
+                'badge-error':   inv.estado === 'Mantenimiento',
+                'badge-neutral': inv.estado === 'Sin sensores'
+              }"
+            >{{ inv.estado }}</span>
+          </div>
+
+          <!-- Detalles -->
+          <ul class="text-sm space-y-1 mb-4">
+            <li><strong>Zonas:</strong> {{ inv.zonasActivas ?? 0 }}</li>
+            <li><strong>Sensores:</strong> {{ inv.sensoresActivos ?? 0 }}</li>
+            <li><strong>Creado:</strong> {{ inv.creado_en | date:'short' }}</li>
+          </ul>
+
+          <!-- Acciones -->
+          <div class="flex justify-end space-x-2">
+            <button
+              class="btn btn-sm btn-ghost btn-circle border border-transparent hover:border-success hover:bg-success/10 transition-colors duration-200"
+              (click)="view(inv)"
+              aria-label="Ver invernadero"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+              </svg>
+            </button>
+            <button
+              class="btn btn-sm btn-ghost btn-circle border border-transparent hover:border-success hover:bg-success/10 transition-colors duration-200"
+              (click)="edit(inv)"
+              aria-label="Editar invernadero"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2v-5m-7-5l7-7m0 0l-7 7m7-7H11" />
+              </svg>
+            </button>
+            <button
+              class="btn btn-sm btn-ghost btn-circle border border-transparent hover:border-error hover:bg-error/10 transition-colors duration-200"
+              (click)="delete(inv)"
+              aria-label="Eliminar invernadero"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V5a1 1 0 011-1h6a1 1 0 011 1v2" />
+              </svg>
+            </button>
           </div>
         </div>
       </ng-container>
       <ng-template #cardSkeletons>
-        <div *ngFor="let _ of skeletonArray" class="card p-4 space-y-2 bg-white rounded-lg shadow animate-pulse">
-          <div class="h-4 w-32 bg-base-300 rounded skeleton"></div>
-          <div class="h-4 w-24 bg-base-300 rounded skeleton"></div>
-          <div class="h-4 w-20 bg-base-300 rounded skeleton"></div>
-          <div class="h-4 w-28 bg-base-300 rounded skeleton"></div>
+        <div *ngFor="let _ of skeletonArray" class="card bg-base-100 shadow-lg p-6 animate-pulse space-y-4">
+          <div class="h-4 w-32 rounded bg-base-300 skeleton"></div>
+          <div class="h-4 w-24 rounded bg-base-300 skeleton"></div>
+          <div class="h-4 w-20 rounded bg-base-300 skeleton"></div>
+          <div class="h-4 w-28 rounded bg-base-300 skeleton"></div>
         </div>
       </ng-template>
     </div>


### PR DESCRIPTION
## Summary
- show table and list skeletons while reloading zones or alerts
- make `recargarZonas` fetch data via `ZonaService`
- align mobile greenhouse cards with sensor card UI

## Testing
- `npm test` *(fails: Chrome missing)*

------
https://chatgpt.com/codex/tasks/task_e_68465f15f34c832abf4b883b72e7b5f7