### PR TITLE
Use DaisyUI classes for auth forms and notifications

### DIFF
--- a/tech-farming-frontend/src/app/auth/set-password/set-password.component.html
+++ b/tech-farming-frontend/src/app/auth/set-password/set-password.component.html
@@ -1,48 +1,48 @@
-<section class="fixed inset-0 flex items-center justify-center bg-white px-4">
-  <div class="w-full max-w-md bg-white rounded-xl shadow-lg p-6 space-y-4 border border-gray-200">
+<section class="fixed inset-0 flex items-center justify-center bg-base-100 px-4">
+  <div class="w-full max-w-md bg-base-100 rounded-xl shadow-lg p-6 space-y-4 border border-base-300">
     <!-- Branding -->
     <div class="flex items-center justify-center gap-3 mb-6">
       <span class="text-5xl sm:text-6xl drop-shadow-xl saturate-[1.2]">🌿</span>
-      <h2 class="text-3xl sm:text-4xl font-extrabold text-green-800 tracking-tight">Tech Farming</h2>
+      <h2 class="text-3xl sm:text-4xl font-extrabold text-success tracking-tight">Tech Farming</h2>
     </div>
 
-    <h3 class="text-lg font-bold text-gray-800">Establecer Contraseña</h3>
-    <p class="text-sm text-gray-600">Ingresa y confirma tu nueva contraseña para continuar.</p>
+    <h3 class="text-lg font-bold text-base-content">Establecer Contraseña</h3>
+    <p class="text-sm text-base-content opacity-70">Ingresa y confirma tu nueva contraseña para continuar.</p>
 
     <form [formGroup]="setForm" (ngSubmit)="submit()">
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Contraseña</label>
+        <label class="block text-sm font-medium text-base-content mb-1">Contraseña</label>
         <input type="password" formControlName="password" class="input input-bordered w-full" placeholder="••••••••">
         <p *ngIf="setForm.get('password')?.invalid && setForm.get('password')?.touched"
-          class="text-red-500 text-sm mt-1">
+          class="text-error text-sm mt-1">
           La contraseña debe tener al menos 8 caracteres.
         </p>
       </div>
 
       <div class="mt-4">
-        <label class="block text-sm font-medium text-gray-700 mb-1">Confirmar Contraseña</label>
+        <label class="block text-sm font-medium text-base-content mb-1">Confirmar Contraseña</label>
         <input type="password" formControlName="confirmPassword" class="input input-bordered w-full"
           placeholder="••••••••">
-        <p *ngIf="passwordsDoNotMatch" class="text-red-500 text-sm mt-1">
+        <p *ngIf="passwordsDoNotMatch" class="text-error text-sm mt-1">
           Las contraseñas no coinciden.
         </p>
       </div>
 
       <div class="mt-4 flex justify-end">
-        <button type="submit" class="btn bg-green-600 text-white hover:bg-green-700">Establecer Contraseña</button>
+        <button type="submit" class="btn btn-success text-base-content">Establecer Contraseña</button>
       </div>
     </form>
 
     <!-- Modal de éxito -->
     <div *ngIf="showSuccessModal()" class="fixed inset-0 flex items-center justify-center z-50 backdrop-blur-sm">
-      <div class="relative w-full max-w-md bg-white rounded-xl shadow-lg p-6 space-y-4 border border-gray-400">
-        <h3 class="text-lg font-bold text-green-700 flex items-center gap-2">
+      <div class="relative w-full max-w-md bg-base-100 rounded-xl shadow-lg p-6 space-y-4 border border-base-300">
+        <h3 class="text-lg font-bold text-success flex items-center gap-2">
           ✅ ¡Contraseña creada!
         </h3>
-        <p class="text-sm text-gray-600">Tu contraseña ha sido establecida correctamente. Ya puedes iniciar sesión.</p>
+        <p class="text-sm text-base-content opacity-70">Tu contraseña ha sido establecida correctamente. Ya puedes iniciar sesión.</p>
 
         <div class="flex justify-end mt-4">
-          <button class="btn bg-green-600 text-white hover:bg-green-700" (click)="cerrarModalYRedirigir()">
+          <button class="btn btn-success text-base-content" (click)="cerrarModalYRedirigir()">
             Ir al login
           </button>
         </div>

--- a/tech-farming-frontend/src/app/perfil/components/reset-password/reset-password.component.html
+++ b/tech-farming-frontend/src/app/perfil/components/reset-password/reset-password.component.html
@@ -1,48 +1,48 @@
-<section class="fixed inset-0 flex items-center justify-center bg-white px-4">
-  <div class="w-full max-w-md bg-white rounded-xl shadow-lg p-6 space-y-4 border border-gray-200">
+<section class="fixed inset-0 flex items-center justify-center bg-base-100 px-4">
+  <div class="w-full max-w-md bg-base-100 rounded-xl shadow-lg p-6 space-y-4 border border-base-300">
     <!-- Branding -->
     <div class="flex items-center justify-center gap-3 mb-6">
       <span class="text-5xl sm:text-6xl drop-shadow-xl saturate-[1.2]">🌿</span>
-      <h2 class="text-3xl sm:text-4xl font-extrabold text-green-800 tracking-tight">Tech Farming</h2>
+      <h2 class="text-3xl sm:text-4xl font-extrabold text-success tracking-tight">Tech Farming</h2>
     </div>
 
-    <h3 class="text-lg font-bold text-gray-800">Restablecer Contraseña</h3>
-    <p class="text-sm text-gray-600">Ingresa y confirma tu nueva contraseña para continuar.</p>
+    <h3 class="text-lg font-bold text-base-content">Restablecer Contraseña</h3>
+    <p class="text-sm text-base-content opacity-70">Ingresa y confirma tu nueva contraseña para continuar.</p>
 
     <form [formGroup]="resetForm" (ngSubmit)="submit()">
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Nueva Contraseña</label>
+        <label class="block text-sm font-medium text-base-content mb-1">Nueva Contraseña</label>
         <input type="password" formControlName="password" class="input input-bordered w-full" placeholder="••••••••">
         <p *ngIf="resetForm.get('password')?.invalid && resetForm.get('password')?.touched"
-          class="text-red-500 text-sm mt-1">
+          class="text-error text-sm mt-1">
           La contraseña debe tener al menos 8 caracteres.
         </p>
       </div>
 
       <div class="mt-4">
-        <label class="block text-sm font-medium text-gray-700 mb-1">Confirmar Contraseña</label>
+        <label class="block text-sm font-medium text-base-content mb-1">Confirmar Contraseña</label>
         <input type="password" formControlName="confirmPassword" class="input input-bordered w-full"
           placeholder="••••••••">
-        <p *ngIf="passwordsDoNotMatch" class="text-red-500 text-sm mt-1">
+        <p *ngIf="passwordsDoNotMatch" class="text-error text-sm mt-1">
           Las contraseñas no coinciden.
         </p>
       </div>
 
       <div class="mt-4 flex justify-end">
-        <button type="submit" class="btn bg-green-600 text-white hover:bg-green-700">Restablecer Contraseña</button>
+        <button type="submit" class="btn btn-success text-base-content">Restablecer Contraseña</button>
       </div>
     </form>
 
     <!-- Modal de éxito -->
     <div *ngIf="showSuccessModal()" class="fixed inset-0 flex items-center justify-center z-50 backdrop-blur-sm">
-      <div class="relative w-full max-w-md bg-white rounded-xl shadow-lg p-6 space-y-4 border border-gray-400">
-        <h3 class="text-lg font-bold text-green-700 flex items-center gap-2">
+      <div class="relative w-full max-w-md bg-base-100 rounded-xl shadow-lg p-6 space-y-4 border border-base-300">
+        <h3 class="text-lg font-bold text-success flex items-center gap-2">
           ✅ ¡Contraseña actualizada!
         </h3>
-        <p class="text-sm text-gray-600">Tu contraseña se ha restablecido correctamente. Ya puedes iniciar sesión.</p>
+        <p class="text-sm text-base-content opacity-70">Tu contraseña se ha restablecido correctamente. Ya puedes iniciar sesión.</p>
 
         <div class="flex justify-end mt-4">
-          <button class="btn bg-green-600 text-white hover:bg-green-700" (click)="cerrarModalYRedirigir()">
+          <button class="btn btn-success text-base-content" (click)="cerrarModalYRedirigir()">
             Ir al login
           </button>
         </div>

--- a/tech-farming-frontend/src/app/shared/components/notification.component.ts
+++ b/tech-farming-frontend/src/app/shared/components/notification.component.ts
@@ -11,12 +11,12 @@ import { NotificationService, NotificationPayload } from '../services/notificati
   template: `
     <div
       *ngIf="message"
-      class="fixed bottom-4 right-4 px-4 py-2 rounded-lg shadow-lg text-white transition-opacity duration-300"
+      class="fixed bottom-4 right-4 px-4 py-2 rounded-lg shadow-lg transition-opacity duration-300"
       [ngClass]="{
-        'bg-green-600': type === 'success',
-        'bg-red-600':   type === 'error',
-        'bg-blue-600':  type === 'info',
-        'bg-yellow-600': type === 'warning'
+        'bg-success text-success-content': type === 'success',
+        'bg-error text-error-content':   type === 'error',
+        'bg-info text-info-content':    type === 'info',
+        'bg-warning text-warning-content': type === 'warning'
       }"
       [style.opacity]="visible ? '1' : '0'"
     >


### PR DESCRIPTION
## Summary
- switch auth forms to DaisyUI styles
- align profile reset-password page with DaisyUI theme
- use DaisyUI colors in notification toasts

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846837f3364832aa29692f2ee9d1380