### PR TITLE
Fix dialog closing on umbral actions

### DIFF
--- a/tech-farming-frontend/src/app/alertas/components/umbral-list.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/umbral-list.component.ts
@@ -45,9 +45,9 @@ import { FormsModule } from '@angular/forms';
           </a>
         </div>
         <button
-          *ngIf="puedeCrear" 
-          class="btn bg-transparent border-success text-base-content hover:bg-success hover:text-success-content" 
-          (click)="nuevoUmbral()"
+          *ngIf="puedeCrear"
+          class="btn bg-transparent border-success text-base-content hover:bg-success hover:text-success-content"
+          (click)="nuevoUmbral(); $event.stopPropagation()"
         >
           + Nuevo Umbral
         </button>
@@ -75,7 +75,7 @@ import { FormsModule } from '@angular/forms';
             <td>{{ u.advertencia_min }} – {{ u.advertencia_max }}</td>
             <td>{{ u.critico_min || '-' }} – {{ u.critico_max || '-' }}</td>
             <td class="text-right">
-              <button *ngIf="puedeEditar" class="btn btn-sm btn-outline mr-2" (click)="editar(u)">✏️</button>
+              <button *ngIf="puedeEditar" class="btn btn-sm btn-outline mr-2" (click)="editar(u); $event.stopPropagation()">✏️</button>
               <button *ngIf="puedeEliminar" class="btn btn-sm btn-error" (click)="eliminar(u)">🗑️</button>
             </td>
           </tr>


### PR DESCRIPTION
## Summary
- keep dialog open by stopping propagation on the `+ Nuevo Umbral` and edit buttons

## Testing
- `npm test --silent -- --watch=false --progress=false` *(fails: Property 'title' does not exist on type 'AppComponent')*

------
https://chatgpt.com/codex/tasks/task_e_684685025cc4832ab61049f6804e7cd5