### PR TITLE
Use DaisyUI classes for more UI components

### DIFF
--- a/tech-farming-frontend/src/app/admin/components/admin-create-modal.component.ts
+++ b/tech-farming-frontend/src/app/admin/components/admin-create-modal.component.ts
@@ -12,15 +12,15 @@ import { SupabaseService } from '../../services/supabase.service';
     <!-- Modal de Confirmación de Éxito -->
     <div *ngIf="confirmacionVisible"
         class="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
-      <div class="bg-white p-6 rounded-xl shadow-xl text-center w-[300px] space-y-2">
-        <h3 class="text-xl font-semibold text-green-600">
+      <div class="bg-base-100 p-6 rounded-xl shadow-xl text-center w-[300px] space-y-2 border border-base-300">
+        <h3 class="text-xl font-semibold text-success">
           ✅ ¡Éxito!
         </h3>
         <p>{{ mensajeConfirmacion }}</p>
       </div>
     </div>
 
-    <div class="bg-white rounded-xl shadow-xl p-6 w-full max-w-2xl">
+    <div class="bg-base-100 rounded-xl shadow-xl p-6 w-full max-w-2xl border border-base-300">
       <h3 class="font-bold text-2xl mb-4">Agregar nuevo usuario trabajador</h3>
 
       <!-- FORMULARIO -->
@@ -47,7 +47,7 @@ import { SupabaseService } from '../../services/supabase.service';
         <div class="form-control">
           <label class="label font-semibold">Teléfono</label>
           <div class="flex gap-2 items-center">
-            <span class="text-md font-medium px-2 border rounded bg-gray-100">+56</span>
+            <span class="text-md font-medium px-2 border rounded bg-base-200">+56</span>
             <input [(ngModel)]="nuevoUsuario.telefono" name="telefono" class="input input-bordered w-full" maxlength="9" pattern="[0-9]{7,9}" required />
           </div>
         </div>

--- a/tech-farming-frontend/src/app/admin/components/admin-edit-modal.component.ts
+++ b/tech-farming-frontend/src/app/admin/components/admin-edit-modal.component.ts
@@ -12,22 +12,22 @@ import { firstValueFrom } from 'rxjs';
     <!-- Modal de Confirmación de Éxito -->
     <div *ngIf="confirmacionVisible"
         class="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
-      <div class="bg-white p-6 rounded-xl shadow-xl text-center w-[300px] space-y-2">
-        <h3 class="text-xl font-semibold text-green-600">
+      <div class="bg-base-100 p-6 rounded-xl shadow-xl text-center w-[300px] space-y-2 border border-base-300">
+        <h3 class="text-xl font-semibold text-success">
           ✅ ¡Éxito!
         </h3>
         <p>{{ mensajeConfirmacion }}</p>
       </div>
     </div>
 
-    <div class="bg-white rounded-xl shadow-xl p-6 w-full max-w-2xl">
+    <div class="bg-base-100 rounded-xl shadow-xl p-6 w-full max-w-2xl border border-base-300">
       <h3 class="font-bold text-2xl mb-4">Editar permisos del usuario</h3>
 
       <form class="space-y-4" (ngSubmit)="guardarCambios()">
         <!-- Nombre (solo lectura) -->
         <div class="form-control">
           <label class="label font-semibold">Nombre</label>
-          <input class="input input-bordered w-full bg-gray-100" [value]="usuario.nombre + ' ' + usuario.apellido" disabled />
+          <input class="input input-bordered w-full bg-base-200" [value]="usuario.nombre + ' ' + usuario.apellido" disabled />
         </div>
 
         <!-- Permisos -->

--- a/tech-farming-frontend/src/app/alertas/components/umbral-config-modal.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/umbral-config-modal.component.ts
@@ -20,8 +20,8 @@ import { Sensor } from '../../sensores/models/sensor.model';
     <!-- Modal de Confirmación -->
     <div *ngIf="confirmacionVisible"
          class="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
-      <div class="bg-white p-6 rounded-xl shadow-xl text-center w-[300px] space-y-2">
-        <h3 class="text-xl font-semibold text-green-600">
+      <div class="bg-base-100 p-6 rounded-xl shadow-xl text-center w-[300px] space-y-2 border border-base-300">
+        <h3 class="text-xl font-semibold text-success">
           ✅ ¡Éxito!
         </h3>
         <p>{{ mensajeConfirmacion }}</p>
@@ -31,7 +31,7 @@ import { Sensor } from '../../sensores/models/sensor.model';
     <!-- Modal de Ayuda -->
     <div *ngIf="ayudaVisible"
         class="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
-      <div class="bg-white w-[600px] max-h-[50vh] p-6 rounded-2xl shadow-xl relative overflow-y-auto pr-2">
+      <div class="bg-base-100 w-[600px] max-h-[50vh] p-6 rounded-2xl shadow-xl relative overflow-y-auto pr-2 border border-base-300">
 
         <div class="space-y-4">
           <h3 class="text-xl font-bold text-success">¿Cómo deben relacionarse los valores de advertencia y crítico?</h3>
@@ -48,17 +48,17 @@ import { Sensor } from '../../sensores/models/sensor.model';
             <li>
               <strong>Advertencia Mínima</strong> debe ser menor que la <strong>Advertencia Máxima</strong>.
               <br />
-              <span class="text-gray-500">→ Define un rango aceptable antes de que el sistema emita una advertencia.</span>
+              <span class="text-base-content/60">→ Define un rango aceptable antes de que el sistema emita una advertencia.</span>
             </li>
             <li>
               <strong>Crítico Mínimo</strong> (si se usa) debe ser menor que la <strong>Advertencia Mínima</strong>.
               <br />
-              <span class="text-gray-500">→ Valores demasiado bajos indican un riesgo grave (por ejemplo, temperaturas bajo cero, niveles de humedad extremadamente bajos, etc.).</span>
+              <span class="text-base-content/60">→ Valores demasiado bajos indican un riesgo grave (por ejemplo, temperaturas bajo cero, niveles de humedad extremadamente bajos, etc.).</span>
             </li>
             <li>
               <strong>Crítico Máximo</strong> (si se usa) debe ser mayor que la <strong>Advertencia Máxima</strong>.
               <br />
-              <span class="text-gray-500">→ Valores demasiado altos también son peligrosos (como calor extremo).</span>
+              <span class="text-base-content/60">→ Valores demasiado altos también son peligrosos (como calor extremo).</span>
             </li>
             <li>
               Si defines ambos críticos, el <strong>Crítico Mínimo</strong> debe ser menor que el <strong>Crítico Máximo</strong>.
@@ -84,12 +84,12 @@ import { Sensor } from '../../sensores/models/sensor.model';
     </div>
 
     <!-- Modal Principal -->
-    <div class="w-full max-w-3xl p-6 bg-white rounded-2xl shadow-xl space-y-6">
+    <div class="w-full max-w-3xl p-6 bg-base-100 rounded-2xl shadow-xl space-y-6 border border-base-300">
       <h2 class="text-[1.625rem] font-bold text-success flex items-center gap-2">
         {{ isEdit ? 'Editar Umbral' : 'Crear Umbral' }}
          <button type="button"
                 (click)="mostrarAyuda()"
-                class="btn btn-circle btn-outline border-black text-black"
+                class="btn btn-circle btn-outline border-base-content text-base-content"
                 style="width: 2.25rem; height: 2.25rem; font-size: 1.125rem;"
                 title="¿Cómo funcionan los umbrales?">
           ?

--- a/tech-farming-frontend/src/app/alertas/components/umbral-drawer-wrapper.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/umbral-drawer-wrapper.component.ts
@@ -25,7 +25,7 @@ import {
       <!-- Drawer -->
       <div
         #drawer
-        class="fixed top-0 right-0 h-full bg-white shadow-xl z-50 w-full sm:w-1/2 md:w-1/3 transform transition-transform duration-300 ease-in-out overflow-auto"
+        class="fixed top-0 right-0 h-full bg-base-100 shadow-xl z-50 w-full sm:w-1/2 md:w-1/3 transform transition-transform duration-300 ease-in-out overflow-auto border-l border-base-300"
         [ngClass]="{ 'translate-x-full': closing, 'translate-x-0': !closing }"
       >
         <ng-content></ng-content>

--- a/tech-farming-frontend/src/app/alertas/components/umbral-list.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/umbral-list.component.ts
@@ -12,7 +12,7 @@ import { FormsModule } from '@angular/forms';
   template: `
     <!-- Confirmación Eliminar -->
     <div *ngIf="confirmDeleteVisible" class="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
-      <div class="bg-white p-6 rounded-xl shadow-xl text-center w-[300px] space-y-3">
+      <div class="bg-base-100 p-6 rounded-xl shadow-xl text-center w-[300px] space-y-3 border border-base-300">
         <h3 class="text-lg font-semibold text-error">¿Eliminar Umbral?</h3>
         <p class="text-sm text-base-content/80">Esta acción desactivará el umbral de forma permanente.</p>
         <div class="flex justify-center gap-4 pt-2">
@@ -24,8 +24,8 @@ import { FormsModule } from '@angular/forms';
 
     <!-- Confirmación Éxito -->
     <div *ngIf="deleteExitosoVisible" class="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
-      <div class="bg-white p-6 rounded-xl shadow-xl text-center w-[300px] space-y-2">
-        <h3 class="text-xl font-semibold text-green-600">✅ ¡Éxito!</h3>
+      <div class="bg-base-100 p-6 rounded-xl shadow-xl text-center w-[300px] space-y-2 border border-base-300">
+        <h3 class="text-xl font-semibold text-success">✅ ¡Éxito!</h3>
         <p>{{ mensajeDeleteExitoso }}</p>
       </div>
     </div>

--- a/tech-farming-frontend/src/app/auth/confirm-email/confirm-email.component.ts
+++ b/tech-farming-frontend/src/app/auth/confirm-email/confirm-email.component.ts
@@ -11,8 +11,8 @@ import { RouterModule } from '@angular/router';
     <div class="flex items-center justify-center min-h-screen">
       <div class="text-center space-y-4">
         <h2 class="text-2xl font-bold">📧 Confirmando cambio...</h2>
-        <p *ngIf="estado === 'ok'" class="text-green-600">¡Tu correo fue actualizado correctamente!</p>
-        <p *ngIf="estado === 'error'" class="text-red-600">Hubo un problema al confirmar el cambio de correo.</p>
+        <p *ngIf="estado === 'ok'" class="text-success">¡Tu correo fue actualizado correctamente!</p>
+        <p *ngIf="estado === 'error'" class="text-error">Hubo un problema al confirmar el cambio de correo.</p>
         <div class="mt-4">
           <button class="btn btn-success" routerLink="/">Ir al dashboard</button>
         </div>

--- a/tech-farming-frontend/src/app/auth/set-password/set-password.component.html
+++ b/tech-farming-frontend/src/app/auth/set-password/set-password.component.html
@@ -1,48 +1,48 @@
-<section class="fixed inset-0 flex items-center justify-center bg-white px-4">
-  <div class="w-full max-w-md bg-white rounded-xl shadow-lg p-6 space-y-4 border border-gray-200">
+<section class="fixed inset-0 flex items-center justify-center bg-base-100 px-4">
+  <div class="w-full max-w-md bg-base-100 rounded-xl shadow-lg p-6 space-y-4 border border-base-300">
     <!-- Branding -->
     <div class="flex items-center justify-center gap-3 mb-6">
       <span class="text-5xl sm:text-6xl drop-shadow-xl saturate-[1.2]">🌿</span>
-      <h2 class="text-3xl sm:text-4xl font-extrabold text-green-800 tracking-tight">Tech Farming</h2>
+      <h2 class="text-3xl sm:text-4xl font-extrabold text-success tracking-tight">Tech Farming</h2>
     </div>
 
-    <h3 class="text-lg font-bold text-gray-800">Establecer Contraseña</h3>
-    <p class="text-sm text-gray-600">Ingresa y confirma tu nueva contraseña para continuar.</p>
+    <h3 class="text-lg font-bold text-base-content">Establecer Contraseña</h3>
+    <p class="text-sm text-base-content opacity-70">Ingresa y confirma tu nueva contraseña para continuar.</p>
 
     <form [formGroup]="setForm" (ngSubmit)="submit()">
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Contraseña</label>
+        <label class="block text-sm font-medium text-base-content mb-1">Contraseña</label>
         <input type="password" formControlName="password" class="input input-bordered w-full" placeholder="••••••••">
         <p *ngIf="setForm.get('password')?.invalid && setForm.get('password')?.touched"
-          class="text-red-500 text-sm mt-1">
+          class="text-error text-sm mt-1">
           La contraseña debe tener al menos 8 caracteres.
         </p>
       </div>
 
       <div class="mt-4">
-        <label class="block text-sm font-medium text-gray-700 mb-1">Confirmar Contraseña</label>
+        <label class="block text-sm font-medium text-base-content mb-1">Confirmar Contraseña</label>
         <input type="password" formControlName="confirmPassword" class="input input-bordered w-full"
           placeholder="••••••••">
-        <p *ngIf="passwordsDoNotMatch" class="text-red-500 text-sm mt-1">
+        <p *ngIf="passwordsDoNotMatch" class="text-error text-sm mt-1">
           Las contraseñas no coinciden.
         </p>
       </div>
 
       <div class="mt-4 flex justify-end">
-        <button type="submit" class="btn bg-green-600 text-white hover:bg-green-700">Establecer Contraseña</button>
+        <button type="submit" class="btn btn-success text-base-content">Establecer Contraseña</button>
       </div>
     </form>
 
     <!-- Modal de éxito -->
     <div *ngIf="showSuccessModal()" class="fixed inset-0 flex items-center justify-center z-50 backdrop-blur-sm">
-      <div class="relative w-full max-w-md bg-white rounded-xl shadow-lg p-6 space-y-4 border border-gray-400">
-        <h3 class="text-lg font-bold text-green-700 flex items-center gap-2">
+      <div class="relative w-full max-w-md bg-base-100 rounded-xl shadow-lg p-6 space-y-4 border border-base-300">
+        <h3 class="text-lg font-bold text-success flex items-center gap-2">
           ✅ ¡Contraseña creada!
         </h3>
-        <p class="text-sm text-gray-600">Tu contraseña ha sido establecida correctamente. Ya puedes iniciar sesión.</p>
+        <p class="text-sm text-base-content opacity-70">Tu contraseña ha sido establecida correctamente. Ya puedes iniciar sesión.</p>
 
         <div class="flex justify-end mt-4">
-          <button class="btn bg-green-600 text-white hover:bg-green-700" (click)="cerrarModalYRedirigir()">
+          <button class="btn btn-success text-base-content" (click)="cerrarModalYRedirigir()">
             Ir al login
           </button>
         </div>

--- a/tech-farming-frontend/src/app/perfil/components/reset-password/reset-password.component.html
+++ b/tech-farming-frontend/src/app/perfil/components/reset-password/reset-password.component.html
@@ -1,48 +1,50 @@
-<section class="fixed inset-0 flex items-center justify-center bg-white px-4">
-  <div class="w-full max-w-md bg-white rounded-xl shadow-lg p-6 space-y-4 border border-gray-200">
+<section class="fixed inset-0 flex items-center justify-center bg-base-100 px-4">
+  <div class="w-full max-w-md bg-base-100 rounded-xl shadow-lg p-6 space-y-4 border border-base-300">
     <!-- Branding -->
-    <div class="flex items-center justify-center gap-3 mb-6">
-      <span class="text-5xl sm:text-6xl drop-shadow-xl saturate-[1.2]">🌿</span>
-      <h2 class="text-3xl sm:text-4xl font-extrabold text-green-800 tracking-tight">Tech Farming</h2>
+    <div class="flex justify-center mb-6">
+      <app-logo></app-logo>
     </div>
 
-    <h3 class="text-lg font-bold text-gray-800">Restablecer Contraseña</h3>
-    <p class="text-sm text-gray-600">Ingresa y confirma tu nueva contraseña para continuar.</p>
+    <div class="flex items-center justify-between">
+      <h3 class="text-lg font-bold text-base-content">Restablecer Contraseña</h3>
+      <button type="button" class="btn btn-ghost btn-sm" (click)="goBack()">Volver</button>
+    </div>
+    <p class="text-sm text-base-content opacity-70">Ingresa y confirma tu nueva contraseña para continuar.</p>
 
     <form [formGroup]="resetForm" (ngSubmit)="submit()">
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Nueva Contraseña</label>
+        <label class="block text-sm font-medium text-base-content mb-1">Nueva Contraseña</label>
         <input type="password" formControlName="password" class="input input-bordered w-full" placeholder="••••••••">
         <p *ngIf="resetForm.get('password')?.invalid && resetForm.get('password')?.touched"
-          class="text-red-500 text-sm mt-1">
+          class="text-error text-sm mt-1">
           La contraseña debe tener al menos 8 caracteres.
         </p>
       </div>
 
       <div class="mt-4">
-        <label class="block text-sm font-medium text-gray-700 mb-1">Confirmar Contraseña</label>
+        <label class="block text-sm font-medium text-base-content mb-1">Confirmar Contraseña</label>
         <input type="password" formControlName="confirmPassword" class="input input-bordered w-full"
           placeholder="••••••••">
-        <p *ngIf="passwordsDoNotMatch" class="text-red-500 text-sm mt-1">
+        <p *ngIf="passwordsDoNotMatch" class="text-error text-sm mt-1">
           Las contraseñas no coinciden.
         </p>
       </div>
 
       <div class="mt-4 flex justify-end">
-        <button type="submit" class="btn bg-green-600 text-white hover:bg-green-700">Restablecer Contraseña</button>
+        <button type="submit" class="btn btn-success text-base-content">Restablecer Contraseña</button>
       </div>
     </form>
 
     <!-- Modal de éxito -->
     <div *ngIf="showSuccessModal()" class="fixed inset-0 flex items-center justify-center z-50 backdrop-blur-sm">
-      <div class="relative w-full max-w-md bg-white rounded-xl shadow-lg p-6 space-y-4 border border-gray-400">
-        <h3 class="text-lg font-bold text-green-700 flex items-center gap-2">
+      <div class="relative w-full max-w-md bg-base-100 rounded-xl shadow-lg p-6 space-y-4 border border-base-300">
+        <h3 class="text-lg font-bold text-success flex items-center gap-2">
           ✅ ¡Contraseña actualizada!
         </h3>
-        <p class="text-sm text-gray-600">Tu contraseña se ha restablecido correctamente. Ya puedes iniciar sesión.</p>
+        <p class="text-sm text-base-content opacity-70">Tu contraseña se ha restablecido correctamente. Ya puedes iniciar sesión.</p>
 
         <div class="flex justify-end mt-4">
-          <button class="btn bg-green-600 text-white hover:bg-green-700" (click)="cerrarModalYRedirigir()">
+          <button class="btn btn-success text-base-content" (click)="cerrarModalYRedirigir()">
             Ir al login
           </button>
         </div>

--- a/tech-farming-frontend/src/app/perfil/components/reset-password/reset-password.component.spec.ts
+++ b/tech-farming-frontend/src/app/perfil/components/reset-password/reset-password.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { ResetPasswordComponent } from './reset-password.component';
 
@@ -8,7 +9,7 @@ describe('ResetPasswordComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ResetPasswordComponent]
+      imports: [RouterTestingModule, ResetPasswordComponent]
     })
     .compileComponents();
 

--- a/tech-farming-frontend/src/app/perfil/components/reset-password/reset-password.component.ts
+++ b/tech-farming-frontend/src/app/perfil/components/reset-password/reset-password.component.ts
@@ -1,19 +1,21 @@
 import { Component, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { Router } from '@angular/router';
+import { AppLogoComponent } from '../../../core/components/app-logo.component';
+import { Router, ActivatedRoute } from '@angular/router';
 import { AuthService } from '../../../services/auth.service';
 
 @Component({
   standalone: true,
   selector: 'app-reset-password',
-  imports: [ReactiveFormsModule, CommonModule],
+  imports: [ReactiveFormsModule, CommonModule, AppLogoComponent],
   templateUrl: './reset-password.component.html',
 })
 export class ResetPasswordComponent {
   private _formBuilder = inject(FormBuilder);
   private _authService = inject(AuthService);
   private _router = inject(Router);
+  private _route = inject(ActivatedRoute);
 
   resetForm = this._formBuilder.group({
     password: ['', [Validators.required, Validators.minLength(8)]],
@@ -24,8 +26,10 @@ export class ResetPasswordComponent {
   passwordsDoNotMatch = false;
   showSuccessModal = signal(false);
   sessionActiva = signal(false);
+  fromPerfil = false;
 
   ngOnInit() {
+    this.fromPerfil = this._route.snapshot.queryParamMap.get('from') === 'perfil';
     // Verificar si hay una sesión válida, ya sea normal o de recuperación
     this._authService.session().then(({ data }) => {
       if (data.session) {
@@ -74,5 +78,13 @@ export class ResetPasswordComponent {
     this.showSuccessModal.set(false);
     await this._authService.logout();
     this._router.navigateByUrl('/login');
+  }
+
+  goBack() {
+    if (this.fromPerfil) {
+      this._router.navigateByUrl('/perfil');
+    } else {
+      this._router.navigateByUrl('/dashboard');
+    }
   }
 }

--- a/tech-farming-frontend/src/app/perfil/perfil.component.ts
+++ b/tech-farming-frontend/src/app/perfil/perfil.component.ts
@@ -12,7 +12,7 @@ import { AuthService } from '../services/auth.service';
   template: `
     <!-- Modal cambio de correo -->
     <div *ngIf="confirmarCambioCorreoVisible" class="fixed inset-0 bg-black/30 z-50 flex justify-center items-center">
-      <div class="bg-white p-6 rounded-xl shadow-xl w-[90%] max-w-sm space-y-4 text-center">
+      <div class="bg-base-100 p-6 rounded-xl shadow-xl w-[90%] max-w-sm space-y-4 text-center border border-base-300">
         <h3 class="text-lg font-semibold text-warning">⚠️ Confirmar cambio de correo</h3>
         <p>¿Estás seguro de que deseas cambiar tu correo?<br>Deberás confirmar el nuevo correo desde tu bandeja de entrada.</p>
 
@@ -30,16 +30,16 @@ import { AuthService } from '../services/auth.service';
 
     <!-- Modal Éxito -->
     <div *ngIf="modalExitoVisible" class="fixed inset-0 bg-black/30 z-50 flex justify-center items-center">
-      <div class="bg-white p-6 rounded-xl shadow-xl w-[90%] max-w-sm text-center space-y-3">
-        <h3 class="text-green-600 text-lg font-semibold">✅ ¡Éxito!</h3>
+      <div class="bg-base-100 p-6 rounded-xl shadow-xl w-[90%] max-w-sm text-center space-y-3 border border-base-300">
+        <h3 class="text-success text-lg font-semibold">✅ ¡Éxito!</h3>
         <p>{{ mensajeExito }}</p>
       </div>
     </div>
 
     <!-- Modal Error -->
     <div *ngIf="modalErrorVisible" class="fixed inset-0 bg-black/30 z-50 flex justify-center items-center">
-      <div class="bg-white p-6 rounded-xl shadow-xl w-[90%] max-w-sm text-center space-y-3">
-        <h3 class="text-red-600 text-lg font-semibold">❌ Error</h3>
+      <div class="bg-base-100 p-6 rounded-xl shadow-xl w-[90%] max-w-sm text-center space-y-3 border border-base-300">
+        <h3 class="text-error text-lg font-semibold">❌ Error</h3>
         <p>{{ mensajeError }}</p>
         <button class="btn btn-sm btn-outline mt-3" (click)="modalErrorVisible = false">Cerrar</button>
       </div>
@@ -55,7 +55,7 @@ import { AuthService } from '../services/auth.service';
             <!-- Skeleton -->
             <div
               *ngIf="avatarCargando"
-              class="w-24 h-24 rounded-full bg-gray-300 animate-pulse"
+              class="w-24 h-24 rounded-full bg-base-300 animate-pulse"
             ></div>
 
             <div *ngIf="!avatarCargando" class="w-24 rounded-full ring ring-success ring-offset-base-100 ring-offset-2">
@@ -63,11 +63,11 @@ import { AuthService } from '../services/auth.service';
             </div>
           </div>
           <button
-            class="absolute bottom-0 right-0 bg-white p-1 rounded-full border shadow hover:bg-gray-100 transition"
+            class="absolute bottom-0 right-0 bg-base-100 p-1 rounded-full border shadow hover:bg-base-200 transition"
             (click)="mostrarOpcionesAvatar = !mostrarOpcionesAvatar"
             aria-label="Cambiar avatar"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-base-content" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
               <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 3.487a1.875 1.875 0 112.65 2.65L7.5 18.15l-4 1 1-4L16.862 3.487z" />
             </svg>
           </button>
@@ -312,6 +312,6 @@ export class PerfilComponent {
   }
 
   goToReset() {
-    this.router.navigate(['perfil/reset-password']);
+    this.router.navigate(['perfil/reset-password'], { queryParams: { from: 'perfil' } });
   }
 }

--- a/tech-farming-frontend/src/app/shared/components/notification.component.ts
+++ b/tech-farming-frontend/src/app/shared/components/notification.component.ts
@@ -11,12 +11,12 @@ import { NotificationService, NotificationPayload } from '../services/notificati
   template: `
     <div
       *ngIf="message"
-      class="fixed bottom-4 right-4 px-4 py-2 rounded-lg shadow-lg text-white transition-opacity duration-300"
+      class="fixed bottom-4 right-4 px-4 py-2 rounded-lg shadow-lg transition-opacity duration-300"
       [ngClass]="{
-        'bg-green-600': type === 'success',
-        'bg-red-600':   type === 'error',
-        'bg-blue-600':  type === 'info',
-        'bg-yellow-600': type === 'warning'
+        'bg-success text-success-content': type === 'success',
+        'bg-error text-error-content':   type === 'error',
+        'bg-info text-info-content':    type === 'info',
+        'bg-warning text-warning-content': type === 'warning'
       }"
       [style.opacity]="visible ? '1' : '0'"
     >


### PR DESCRIPTION
## Summary
- align umbral list, drawer, and config modal with DaisyUI styling
- switch confirm-email page to DaisyUI color utilities
- apply DaisyUI colors in admin create/edit modals
- style perfil section with DaisyUI and support returning from reset password
- replace reset password branding with the `app-logo` component

## Testing
- `npm test --silent` *(fails: Chrome binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846837f3364832aa29692f2ee9d1380