### PR TITLE
Add loading states for admin and alert pages

### DIFF
--- a/tech-farming-frontend/src/app/admin/components/admin-table.component.ts
+++ b/tech-farming-frontend/src/app/admin/components/admin-table.component.ts
@@ -31,7 +31,7 @@ interface Usuario {
             <th class="text-center">Acciones</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody *ngIf="!loading; else loadingRows">
           <tr *ngFor="let u of usuarios">
             <td>{{ u.nombre }}</td>
             <td>{{ u.apellido }}</td>
@@ -45,6 +45,13 @@ interface Usuario {
             </td>
           </tr>
         </tbody>
+        <ng-template #loadingRows>
+          <tr *ngFor="let _ of skeletonArray">
+            <td colspan="8">
+              <div class="skeleton h-6 w-full rounded bg-base-300 animate-pulse opacity-60"></div>
+            </td>
+          </tr>
+        </ng-template>
       </table>
 
       <!-- Paginación -->
@@ -87,6 +94,8 @@ export class AdminTableComponent {
   @Input() paginaActual = 1;
   @Input() totalPaginas = 1;
   @Input() totalUsuarios = 0;
+  @Input() loading = false;
+  @Input() rowCount = 5;
   @Output() paginaCambiada = new EventEmitter<number>();
   @Output() editarUsuario = new EventEmitter<Usuario>();
 
@@ -111,5 +120,9 @@ export class AdminTableComponent {
     }
 
     return items;
+  }
+
+  get skeletonArray() {
+    return Array.from({ length: this.rowCount });
   }
 }

--- a/tech-farming-frontend/src/app/alertas/components/alertas-activas.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/alertas-activas.component.ts
@@ -18,7 +18,7 @@ import { Alerta } from '../../models/index';
           <th class="text-right">Acciones</th>
         </tr>
       </thead>
-      <tbody>
+      <tbody *ngIf="!loading; else loadingRows">
         <tr *ngFor="let a of alertas">
           <td>{{ a.fecha_hora | date:'short' }}</td>
           <td>{{ a.sensor_nombre || '-' }}</td>
@@ -49,11 +49,24 @@ import { Alerta } from '../../models/index';
           </td>
         </tr>
       </tbody>
+      <ng-template #loadingRows>
+        <tr *ngFor="let _ of skeletonArray">
+          <td colspan="6">
+            <div class="skeleton h-6 w-full rounded bg-base-300 animate-pulse opacity-60"></div>
+          </td>
+        </tr>
+      </ng-template>
     </table>
   `
 })
 export class ActiveAlertsComponent {
   @Input() alertas: Alerta[] = [];
   @Input() resolviendoId: number | null = null;
+  @Input() loading = false;
+  @Input() rowCount = 5;
   @Output() resolver = new EventEmitter<Alerta>();
+
+  get skeletonArray() {
+    return Array.from({ length: this.rowCount });
+  }
 }

--- a/tech-farming-frontend/src/app/alertas/components/alertas-historial.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/alertas-historial.component.ts
@@ -18,7 +18,7 @@ import { Alerta } from '../../models/index';
           <th>Resuelta por</th>
         </tr>
       </thead>
-      <tbody>
+      <tbody *ngIf="!loading; else loadingRows">
         <tr *ngFor="let a of alertas">
           <td>{{ a.fecha_hora | date:'short' }}</td>
           <td>{{ a.sensor_nombre || '-' }}</td>
@@ -38,9 +38,22 @@ import { Alerta } from '../../models/index';
           <td>{{ a.resuelta_por }}</td>
         </tr>
       </tbody>
+      <ng-template #loadingRows>
+        <tr *ngFor="let _ of skeletonArray">
+          <td colspan="6">
+            <div class="skeleton h-6 w-full rounded bg-base-300 animate-pulse opacity-60"></div>
+          </td>
+        </tr>
+      </ng-template>
     </table>
   `
 })
 export class AlertsHistoryComponent {
   @Input() alertas: Alerta[] = [];
+  @Input() loading = false;
+  @Input() rowCount = 5;
+
+  get skeletonArray() {
+    return Array.from({ length: this.rowCount });
+  }
 }


### PR DESCRIPTION
## Summary
- add loading helpers to `AlertasComponent` and show spinners
- update alert subcomponents with skeleton rows when loading
- introduce loading state in admin section and table

## Testing
- `npm test --silent` *(fails: No Chrome binary available)*

------
https://chatgpt.com/codex/tasks/task_e_684778de7f4c832a9563dcfa7dbd0000