### PR TITLE
Fix session restoration to avoid login flash

### DIFF
--- a/tech-farming-frontend/src/app/app.config.ts
+++ b/tech-farming-frontend/src/app/app.config.ts
@@ -1,10 +1,16 @@
-import { ApplicationConfig } from '@angular/core';
+import { ApplicationConfig, APP_INITIALIZER, inject } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { routes } from './app.routes';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { authInterceptor } from './auth/auth.interceptor';
+import { AuthService } from './services/auth.service';
+
+function initAuth() {
+  const auth = inject(AuthService);
+  return () => auth.restoreSession();
+}
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -13,7 +19,12 @@ export const appConfig: ApplicationConfig = {
       withFetch(),
     withInterceptors([authInterceptor]),
     ),
-    provideAnimations(),   
+    provideAnimations(),
     OverlayModule,
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initAuth,
+      multi: true,
+    },
   ],
 };

--- a/tech-farming-frontend/src/app/guards/auth.guard.ts
+++ b/tech-farming-frontend/src/app/guards/auth.guard.ts
@@ -6,26 +6,26 @@ const routerInjection = () => inject(Router);
 
 const authService = () => inject(AuthService);
 
-export const privateGuard: CanActivateFn = async () => {
+export const privateGuard: CanActivateFn = () => {
   const router = routerInjection();
 
-  const { data } = await authService().session();
+  const session = authService().currentSession;
 
-  if (!data.session) {
+  if (!session) {
     router.navigateByUrl('/login');
   }
 
-  return !!data.session;
+  return !!session;
 };
 
-export const publicGuard: CanActivateFn = async () => {
+export const publicGuard: CanActivateFn = () => {
   const router = routerInjection();
 
-  const { data } = await authService().session();
+  const session = authService().currentSession;
 
-  if (data.session) {
+  if (session) {
     router.navigateByUrl('/');
   }
 
-  return !data.session;
+  return !session;
 };

--- a/tech-farming-frontend/src/app/services/auth.service.ts
+++ b/tech-farming-frontend/src/app/services/auth.service.ts
@@ -1,25 +1,41 @@
 import { Injectable, inject } from '@angular/core';
 import { SupabaseService } from '../services/supabase.service';
-import { SignUpWithPasswordCredentials } from '@supabase/supabase-js';
+import { Session, SignUpWithPasswordCredentials } from '@supabase/supabase-js';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private _supabaseClient = inject(SupabaseService).supabase;
 
-  session() {
-    return this._supabaseClient.auth.getSession();
+  private _currentSession: Session | null = null;
+
+  get currentSession() {
+    return this._currentSession;
+  }
+
+  async restoreSession() {
+    const { data } = await this._supabaseClient.auth.getSession();
+    this._currentSession = data.session;
+  }
+
+  async session() {
+    const { data } = await this._supabaseClient.auth.getSession();
+    this._currentSession = data.session;
+    return { data };
   }
 
   getClient() {
     return this._supabaseClient;
   }
 
-  login(credentials: SignUpWithPasswordCredentials) {
-    return this._supabaseClient.auth.signInWithPassword(credentials);
+  async login(credentials: SignUpWithPasswordCredentials) {
+    const result = await this._supabaseClient.auth.signInWithPassword(credentials);
+    this._currentSession = result.data.session;
+    return result;
   }
 
-  logout() {
-    return this._supabaseClient.auth.signOut();
+  async logout() {
+    await this._supabaseClient.auth.signOut();
+    this._currentSession = null;
   }
 
   async resetPassword(email: string): Promise<{ error: any | null }> {


### PR DESCRIPTION
## Summary
- store Supabase session in `AuthService`
- update route guards to use the stored session
- add an `APP_INITIALIZER` to restore the session before routing

## Testing
- `npm test` *(fails: No binary for Chrome)*
- `npm run build` *(fails: build error in perfil.component.ts)*

------
https://chatgpt.com/codex/tasks/task_e_684776082c5c832a85150425c2a9c82e