### PR TITLE
Fix session guards and subscribe to auth updates

### DIFF
--- a/tech-farming-frontend/src/app/guards/auth.guard.ts
+++ b/tech-farming-frontend/src/app/guards/auth.guard.ts
@@ -6,26 +6,30 @@ const routerInjection = () => inject(Router);
 
 const authService = () => inject(AuthService);
 
-export const privateGuard: CanActivateFn = () => {
+export const privateGuard: CanActivateFn = async () => {
   const router = routerInjection();
 
-  const session = authService().currentSession;
+  const { data } = await authService().session();
+  const session = data.session;
 
   if (!session) {
     router.navigateByUrl('/login');
+    return false;
   }
 
-  return !!session;
+  return true;
 };
 
-export const publicGuard: CanActivateFn = () => {
+export const publicGuard: CanActivateFn = async () => {
   const router = routerInjection();
 
-  const session = authService().currentSession;
+  const { data } = await authService().session();
+  const session = data.session;
 
   if (session) {
     router.navigateByUrl('/');
+    return false;
   }
 
-  return !session;
+  return true;
 };

--- a/tech-farming-frontend/src/app/services/auth.service.ts
+++ b/tech-farming-frontend/src/app/services/auth.service.ts
@@ -8,6 +8,12 @@ export class AuthService {
 
   private _currentSession: Session | null = null;
 
+  constructor() {
+    this._supabaseClient.auth.onAuthStateChange((_event, session) => {
+      this._currentSession = session;
+    });
+  }
+
   get currentSession() {
     return this._currentSession;
   }


### PR DESCRIPTION
## Summary
- update `AuthService` to track auth state changes automatically
- ensure guards await session retrieval

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68478c10a0a8832aabd037a8107275a3