### PR TITLE
Add loading states to sensor modals

### DIFF
--- a/tech-farming-frontend/src/app/sensores/components/sensor-delete-modal.component.ts
+++ b/tech-farming-frontend/src/app/sensores/components/sensor-delete-modal.component.ts
@@ -9,20 +9,24 @@ import { Sensor }                                from '../models/sensor.model';
   standalone: true,
   imports: [CommonModule],
   template: `
+    <div *ngIf="!loading; else loadingTpl">
     <div class="p-6 bg-base-100 rounded-lg shadow-lg max-w-md w-full space-y-4">
       <h2 class="text-xl font-bold text-error">⚠️ Eliminar sensor</h2>
       <p>¿Estás seguro de que quieres eliminar el sensor <strong>{{ sensor.nombre }}</strong>?</p>
       <div class="flex justify-end space-x-2">
-        <button class="btn btn-ghost " (click)="close.emit()">Cancelar</button>
-        <button
-          class="btn btn-error"
-          [disabled]="loading"
-          (click)="onDelete()"
-        >
-          {{ loading ? 'Eliminando…' : 'Eliminar' }}
-        </button>
+        <button class="btn btn-ghost" (click)="close.emit()" [disabled]="loading">Cancelar</button>
+        <button class="btn btn-error" [disabled]="loading" (click)="onDelete()">Eliminar</button>
       </div>
     </div>
+    </div>
+    <ng-template #loadingTpl>
+      <div class="p-6 text-center">
+        <svg class="animate-spin w-8 h-8 text-error mx-auto" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"></path>
+        </svg>
+      </div>
+    </ng-template>
   `
 })
 export class SensorDeleteModalComponent {

--- a/tech-farming-frontend/src/app/sensores/components/sensor-view-modal.component.ts
+++ b/tech-farming-frontend/src/app/sensores/components/sensor-view-modal.component.ts
@@ -21,6 +21,7 @@ import {
     standalone: true,
     imports: [CommonModule],
     template: `
+      <div *ngIf="!loading; else loadingTpl">
       <div
         class="p-6 bg-base-100 rounded-lg shadow-xl w-full
                max-w-md sm:max-w-3xl lg:max-w-4xl
@@ -102,7 +103,7 @@ import {
             </div>
   
           <!-- Spinner -->
-          <div *ngIf="loading"><progress class="progress w-full"></progress></div>
+          <!-- placeholder removed; spinner now handled globally -->
   
           <!-- GRÁFICOS -->
           <ng-container *ngIf="!loading && series.length">
@@ -127,6 +128,15 @@ import {
           </div>
         </section>
       </div>
+      </div>
+      <ng-template #loadingTpl>
+        <div class="p-8 text-center">
+          <svg class="animate-spin w-8 h-8 text-success mx-auto" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"></path>
+          </svg>
+        </div>
+      </ng-template>
     `
   })
   export class SensorViewModalComponent implements OnInit, OnDestroy {


### PR DESCRIPTION
## Summary
- add consistent loading spinners to sensor modals
- disable form controls while creating/editing/deleting sensors
- show a spinner when viewing sensor history

## Testing
- `npm test --prefix tech-farming-frontend` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68478bca3d0c832ab3c2807dffc7d22d