### PR TITLE
Fix alert filters reload

### DIFF
--- a/tech-farming-frontend/src/app/alertas/alertas.component.ts
+++ b/tech-farming-frontend/src/app/alertas/alertas.component.ts
@@ -323,19 +323,8 @@ export class AlertasComponent implements OnInit, OnDestroy {
   }
 
   aplicarFiltros() {
-    const f = this.filterForm.getRawValue();
-    const estado = this.tabIndex === 0 ? 'Activa' : 'Resuelta';
-
-    this.alertService.getAlertas(
-      estado,
-      f.nivel || undefined,
-      f.invernadero || undefined,
-      f.zona || undefined,
-      f.sensor || undefined
-    ).subscribe(resp => {
-      if (estado === 'Activa') this.alertasActivas = resp.data;
-      else this.alertasResueltas = resp.data;
-    });
+    this.currentPage = 1;
+    this.cargarAlertas();
   }
 
   limpiarFiltros() {
@@ -351,12 +340,8 @@ export class AlertasComponent implements OnInit, OnDestroy {
     this.filterForm.get('zona')!.disable({ emitEvent: false });
     this.filterForm.get('sensor')!.disable({ emitEvent: false });
 
-    const estado = this.tabIndex === 0 ? 'Activa' : 'Resuelta';
-    this.alertService.getAlertas(estado)
-      .subscribe(resp => {
-        if (estado === 'Activa') this.alertasActivas = resp.data;
-        else this.alertasResueltas = resp.data;
-      });
+    this.currentPage = 1;
+    this.cargarAlertas();
   }
 
   filtrosActivos(): Array<{ key: string; label: string }> {


### PR DESCRIPTION
## Summary
- use `cargarAlertas()` when applying and clearing filters
- reset pagination when filters change

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6847905370a4832ab1cfe47c32a8c637