### PR TITLE
Enable sensor filtering in alert listing

### DIFF
--- a/tech-farming-backend/app/routes/alertas.py
+++ b/tech-farming-backend/app/routes/alertas.py
@@ -15,6 +15,7 @@ def obtener_alertas():
             "nivel": request.args.get("nivel"),
             "invernadero_id": request.args.get("invernadero_id", type=int),
             "zona_id": request.args.get("zona_id", type=int),
+            "sensor_id": request.args.get("sensor_id", type=int),
             "busqueda": request.args.get("busqueda"),
             "page": request.args.get("page", default=1, type=int),
             "perPage": request.args.get("perPage", default=20, type=int)

--- a/tech-farming-frontend/src/app/alertas/alertas.component.ts
+++ b/tech-farming-frontend/src/app/alertas/alertas.component.ts
@@ -409,6 +409,7 @@ export class AlertasComponent implements OnInit, OnDestroy {
       f.invernadero || undefined,
       f.zona || undefined,
       f.sensor || undefined,
+      undefined,
       this.currentPage,
       this.pageSize
     ).subscribe(resp => {
@@ -437,6 +438,7 @@ export class AlertasComponent implements OnInit, OnDestroy {
         f.invernadero,
         f.zona,
         f.sensor,
+        undefined,
         this.currentPage,
         this.pageSize
       ),
@@ -446,6 +448,7 @@ export class AlertasComponent implements OnInit, OnDestroy {
         f.invernadero,
         f.zona,
         f.sensor,
+        undefined,
         this.currentPage,
         this.pageSize
       )

--- a/tech-farming-frontend/src/app/alertas/alertas.service.ts
+++ b/tech-farming-frontend/src/app/alertas/alertas.service.ts
@@ -30,6 +30,7 @@ export class AlertService {
     nivel?: 'Advertencia' | 'Crítico',
     invernadero_id?: number,
     zona_id?: number,
+    sensor_id?: number,
     busqueda?: string,
     page: number = 1,
     perPage: number = 20
@@ -43,6 +44,7 @@ export class AlertService {
     if (nivel) params = params.set('nivel', nivel);
     if (invernadero_id) params = params.set('invernadero_id', invernadero_id.toString());
     if (zona_id) params = params.set('zona_id', zona_id.toString());
+    if (sensor_id) params = params.set('sensor_id', sensor_id.toString());
     if (busqueda) params = params.set('busqueda', busqueda);
     return this.http.get<{ data: Alerta[]; pagination: any }>(this.baseUrl, { params });
   }

--- a/tech-farming-frontend/src/app/dashboard/services/dashboard.service.ts
+++ b/tech-farming-frontend/src/app/dashboard/services/dashboard.service.ts
@@ -64,6 +64,7 @@ export class DashboardService {
     nivel?: 'Advertencia' | 'Crítico';
     invernadero_id?: number;
     zona_id?: number;
+    sensor_id?: number;
     busqueda?: string;
     page?: number;
     perPage?: number;
@@ -73,6 +74,7 @@ export class DashboardService {
       filtros.nivel,
       filtros.invernadero_id,
       filtros.zona_id,
+      filtros.sensor_id,
       filtros.busqueda,
       filtros.page,
       filtros.perPage


### PR DESCRIPTION
## Summary
- pass `sensor_id` in alert filter query
- forward sensor filter from Angular service and dashboard
- keep pagination when sensor filter is used

## Testing
- `npm test --prefix tech-farming-frontend --silent` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_68479054ad30832abdb92d241e0eca26