### PR TITLE
Update sensor filtering logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,9 @@ La solución integra lectura de sensores que miden:
 - Predicción avanzada con LSTM o Random Forest.
 
 ---
+
+## 📒 Backend
+
+Algunas alertas históricas se generaron antes de contar con el campo
+`sensor_id`. Por compatibilidad, el listado verifica tanto `Alerta.sensor_id`
+como el sensor asociado al `sensor_parametro` cuando se filtra por sensor.

--- a/tech-farming-backend/app/queries/alerta_queries.py
+++ b/tech-farming-backend/app/queries/alerta_queries.py
@@ -149,7 +149,16 @@ def listar_alertas(filtros: dict):
             Alerta.sensor.has(Sensor.zona_id == filtros["zona_id"])
         ))
     if filtros.get("sensor_id"):
-        query = query.filter(Alerta.sensor_id == filtros["sensor_id"])
+        sid = filtros["sensor_id"]
+        query = query.filter(or_(
+            Alerta.sensor_id == sid,
+            and_(
+                Alerta.sensor_id.is_(None),
+                Alerta.sensor_parametro.has(
+                    SensorParametro.sensor_id == sid
+                )
+            )
+        ))
 
     paginated = query.order_by(Alerta.fecha_hora.desc()).paginate(page=page, per_page=per_page)
 


### PR DESCRIPTION
## Summary
- support legacy alerts without `sensor_id` in `listar_alertas`
- document why sensor fallback is required

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684797872a30832a95369268df261b61