### PR TITLE
Improve responsiveness for alerts and admin

### DIFF
--- a/tech-farming-frontend/src/app/admin/admin.component.ts
+++ b/tech-farming-frontend/src/app/admin/admin.component.ts
@@ -8,6 +8,7 @@ import { AdminTableComponent } from './components/admin-table.component';
 import { AdminCreateModalComponent } from './components/admin-create-modal.component';
 import { AdminEditModalComponent } from './components/admin-edit-modal.component';
 import { AdminModalWrapperComponent } from './components/admin-modal-wrapper.component';
+import { AdminCardListComponent } from './components/admin-card-list.component';
 
 interface Usuario {
   id: number;
@@ -28,6 +29,7 @@ interface Usuario {
     AdminHeaderComponent,
     AdminFiltersComponent,
     AdminTableComponent,
+    AdminCardListComponent,
     AdminCreateModalComponent,
     AdminEditModalComponent,
     AdminModalWrapperComponent],
@@ -35,15 +37,25 @@ interface Usuario {
     <div *ngIf="!loading; else loadingTpl">
     <app-admin-header (create)="abrirModal()"></app-admin-header>
     <app-admin-filters (buscar)="filtrar($event)"></app-admin-filters>
-    <app-admin-table
+    <div class="hidden md:block">
+      <app-admin-table
+        [usuarios]="usuariosFiltrados"
+        [paginaActual]="paginaActual"
+        [totalPaginas]="totalPaginas"
+        [loading]="!isDataFullyLoaded"
+        [rowCount]="pageSize"
+        (paginaCambiada)="cambiarPagina($event)"
+        (editarUsuario)="editar($event)">
+      </app-admin-table>
+    </div>
+
+    <app-admin-card-list
+      class="md:hidden"
       [usuarios]="usuariosFiltrados"
-      [paginaActual]="paginaActual"
-      [totalPaginas]="totalPaginas"
       [loading]="!isDataFullyLoaded"
       [rowCount]="pageSize"
-      (paginaCambiada)="cambiarPagina($event)"
       (editarUsuario)="editar($event)">
-    </app-admin-table>
+    </app-admin-card-list>
 
     <app-admin-modal-wrapper *ngIf="modal.modalType$ | async as type">
       <ng-container [ngSwitch]="type">

--- a/tech-farming-frontend/src/app/admin/components/admin-card-list.component.ts
+++ b/tech-farming-frontend/src/app/admin/components/admin-card-list.component.ts
@@ -1,0 +1,55 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface Usuario {
+  id: number;
+  nombre: string;
+  apellido: string;
+  email: string;
+  telefono: string;
+  puedeEditar: boolean;
+  puedeCrear: boolean;
+  puedeEliminar: boolean;
+}
+
+@Component({
+  selector: 'app-admin-card-list',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="md:hidden space-y-4 p-6">
+      <ng-container *ngIf="!loading; else skeletons">
+        <div *ngFor="let u of usuarios" class="card bg-base-100 shadow-lg p-4 space-y-2">
+          <h3 class="font-semibold text-lg">{{ u.nombre }} {{ u.apellido }}</h3>
+          <div class="text-sm">{{ u.email }}</div>
+          <div class="text-sm">{{ u.telefono }}</div>
+          <div class="text-sm flex gap-2">
+            <span>Editar: {{ u.puedeEditar ? '✔️' : '❌' }}</span>
+            <span>Crear: {{ u.puedeCrear ? '✔️' : '❌' }}</span>
+            <span>Eliminar: {{ u.puedeEliminar ? '✔️' : '❌' }}</span>
+          </div>
+          <div class="text-right">
+            <button class="btn btn-outline btn-sm" (click)="editarUsuario.emit(u)">Editar</button>
+          </div>
+        </div>
+      </ng-container>
+      <ng-template #skeletons>
+        <div *ngFor="let _ of skeletonArray" class="card bg-base-100 shadow-lg p-4 animate-pulse space-y-2">
+          <div class="h-4 w-32 bg-base-300 rounded"></div>
+          <div class="h-4 w-24 bg-base-300 rounded"></div>
+          <div class="h-4 w-20 bg-base-300 rounded"></div>
+        </div>
+      </ng-template>
+    </div>
+  `,
+})
+export class AdminCardListComponent {
+  @Input() usuarios: Usuario[] = [];
+  @Input() loading = false;
+  @Input() rowCount = 5;
+  @Output() editarUsuario = new EventEmitter<Usuario>();
+
+  get skeletonArray() {
+    return Array.from({ length: this.rowCount });
+  }
+}

--- a/tech-farming-frontend/src/app/admin/components/admin-create-modal.component.ts
+++ b/tech-farming-frontend/src/app/admin/components/admin-create-modal.component.ts
@@ -20,7 +20,7 @@ import { SupabaseService } from '../../services/supabase.service';
       </div>
     </div>
 
-    <div class="bg-base-100 rounded-xl shadow-xl p-6 w-full max-w-2xl border border-base-300">
+    <div class="bg-base-100 rounded-xl shadow-xl p-6 w-full max-w-[90vw] sm:max-w-2xl border border-base-300">
       <h3 class="font-bold text-2xl mb-4">Agregar nuevo usuario trabajador</h3>
 
       <!-- FORMULARIO -->

--- a/tech-farming-frontend/src/app/admin/components/admin-edit-modal.component.ts
+++ b/tech-farming-frontend/src/app/admin/components/admin-edit-modal.component.ts
@@ -20,7 +20,7 @@ import { firstValueFrom } from 'rxjs';
       </div>
     </div>
 
-    <div class="bg-base-100 rounded-xl shadow-xl p-6 w-full max-w-2xl border border-base-300">
+    <div class="bg-base-100 rounded-xl shadow-xl p-6 w-full max-w-[90vw] sm:max-w-2xl border border-base-300">
       <h3 class="font-bold text-2xl mb-4">Editar permisos del usuario</h3>
 
       <form class="space-y-4" (ngSubmit)="guardarCambios()">

--- a/tech-farming-frontend/src/app/admin/components/admin-modal-wrapper.component.ts
+++ b/tech-farming-frontend/src/app/admin/components/admin-modal-wrapper.component.ts
@@ -21,7 +21,7 @@ import { AdminModalService } from '../admin-modal.service';
     <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div
         #modalContent
-        class="bg-base-100 rounded-lg shadow-2xl overflow-hidden transition-all w-full max-w-xl"
+        class="bg-base-100 rounded-lg shadow-2xl overflow-hidden transition-all w-full max-w-[95vw] sm:max-w-xl"
         [ngClass]="{ 'animate-fadeInZoom': !closing, 'animate-fadeOutZoom': closing }"
       >
         <ng-content></ng-content>

--- a/tech-farming-frontend/src/app/alertas/alertas.component.ts
+++ b/tech-farming-frontend/src/app/alertas/alertas.component.ts
@@ -9,6 +9,7 @@ import { ActiveAlertsComponent } from './components/alertas-activas.component';
 import { AlertsHistoryComponent } from './components/alertas-historial.component';
 import { UmbralModalWrapperComponent } from './components/umbral-modal-wrapper.component';
 import { UmbralConfigModalComponent } from './components/umbral-config-modal.component';
+import { AlertCardListComponent } from './components/alert-card-list.component';
 import { HistorialService } from '../historial/historial.service';
 import { InvernaderoService } from '../invernaderos/invernaderos.service';
 import { ZonaService } from '../invernaderos/zona.service';
@@ -24,6 +25,7 @@ import { UmbralListComponent } from './components/umbral-list.component';
     ReactiveFormsModule,
     AlertsHeaderComponent,
     ActiveAlertsComponent,
+    AlertCardListComponent,
     AlertsHistoryComponent,
     UmbralConfigModalComponent,
     UmbralListComponent,
@@ -151,20 +153,39 @@ import { UmbralListComponent } from './components/umbral-list.component';
 
       <!-- Contenido de cada tab -->
       <div *ngIf="tabIndex === 0" class="mt-4">
-        <app-active-alerts
+        <div class="hidden md:block">
+          <app-active-alerts
+            [alertas]="alertasActivas"
+            [resolviendoId]="resolviendoId"
+            [loading]="!isDataFullyLoaded"
+            [rowCount]="pageSize"
+            (resolver)="resolverAlerta($event)">
+          </app-active-alerts>
+        </div>
+        <app-alert-card-list
+          class="md:hidden"
           [alertas]="alertasActivas"
           [resolviendoId]="resolviendoId"
           [loading]="!isDataFullyLoaded"
           [rowCount]="pageSize"
+          [showResolver]="true"
           (resolver)="resolverAlerta($event)">
-        </app-active-alerts>
+        </app-alert-card-list>
       </div>
       <div *ngIf="tabIndex === 1" class="mt-4">
-        <app-alerts-history
+        <div class="hidden md:block">
+          <app-alerts-history
+            [alertas]="alertasResueltas"
+            [loading]="!isDataFullyLoaded"
+            [rowCount]="pageSize">
+          </app-alerts-history>
+        </div>
+        <app-alert-card-list
+          class="md:hidden"
           [alertas]="alertasResueltas"
           [loading]="!isDataFullyLoaded"
           [rowCount]="pageSize">
-        </app-alerts-history>
+        </app-alert-card-list>
       </div>
 
       <!-- Modal de configuración de Umbrales -->

--- a/tech-farming-frontend/src/app/alertas/components/alert-card-list.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/alert-card-list.component.ts
@@ -1,0 +1,51 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Alerta } from '../models/index';
+
+@Component({
+  selector: 'app-alert-card-list',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="md:hidden space-y-4 p-6">
+      <ng-container *ngIf="!loading; else skeletons">
+        <div *ngFor="let a of alertas" class="card bg-base-100 shadow p-4 space-y-2">
+          <div class="flex justify-between items-start">
+            <span class="text-sm">{{ a.fecha_hora | date:'short' }}</span>
+            <span class="badge badge-sm" [ngClass]="{ 'badge-warning': a.nivel === 'Advertencia', 'badge-error': a.nivel === 'Crítico' }">
+              {{ a.nivel }}
+            </span>
+          </div>
+          <div class="text-sm">{{ a.sensor_nombre || '-' }} · {{ a.tipo_parametro || '-' }}</div>
+          <p class="text-sm">{{ a.mensaje }}</p>
+          <div *ngIf="a.resuelta_por" class="text-xs text-base-content/60">Resuelta por {{ a.resuelta_por }}</div>
+          <div class="text-right" *ngIf="showResolver">
+            <button class="btn btn-outline btn-sm" (click)="resolver.emit(a)" [disabled]="resolviendoId === a.id">
+              <ng-container *ngIf="resolviendoId === a.id; else txt"> <span class="loading loading-spinner loading-sm"></span> </ng-container>
+              <ng-template #txt>Resolver</ng-template>
+            </button>
+          </div>
+        </div>
+      </ng-container>
+      <ng-template #skeletons>
+        <div *ngFor="let _ of skeletonArray" class="card bg-base-100 shadow p-4 animate-pulse space-y-2">
+          <div class="h-4 w-24 bg-base-300 rounded"></div>
+          <div class="h-4 w-20 bg-base-300 rounded"></div>
+          <div class="h-4 w-32 bg-base-300 rounded"></div>
+        </div>
+      </ng-template>
+    </div>
+  `,
+})
+export class AlertCardListComponent {
+  @Input() alertas: Alerta[] = [];
+  @Input() resolviendoId: number | null = null;
+  @Input() loading = false;
+  @Input() rowCount = 5;
+  @Input() showResolver = false;
+  @Output() resolver = new EventEmitter<Alerta>();
+
+  get skeletonArray() {
+    return Array.from({ length: this.rowCount });
+  }
+}

--- a/tech-farming-frontend/src/app/alertas/components/umbral-config-modal.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/umbral-config-modal.component.ts
@@ -84,7 +84,7 @@ import { Sensor } from '../../sensores/models/sensor.model';
     </div>
 
     <!-- Modal Principal -->
-    <div class="w-full max-w-3xl p-6 bg-base-100 rounded-2xl shadow-xl space-y-6 border border-base-300">
+    <div class="w-full max-w-[95vw] sm:max-w-3xl p-6 bg-base-100 rounded-2xl shadow-xl space-y-6 border border-base-300">
       <h2 class="text-[1.625rem] font-bold text-success flex items-center gap-2">
         {{ isEdit ? 'Editar Umbral' : 'Crear Umbral' }}
          <button type="button"

--- a/tech-farming-frontend/src/app/alertas/components/umbral-modal-wrapper.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/umbral-modal-wrapper.component.ts
@@ -11,7 +11,7 @@ import { UmbralModalService } from '../umbral-modal.service';
 
       <div
         #modalContent
-        class="modal-box bg-base-100 rounded-2xl shadow-xl w-full max-w-3xl overflow-auto"
+        class="modal-box bg-base-100 rounded-2xl shadow-xl w-full max-w-[95vw] sm:max-w-3xl overflow-auto"
       >
         <ng-content></ng-content>
       </div>


### PR DESCRIPTION
## Summary
- add mobile card list for alerts
- add mobile card list for admin users
- make alert and admin modals responsive

## Testing
- `npm test` *(fails: No Chrome binary)*
- `pytest` *(fails: ModuleNotFoundError: dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68479f59c104832a9bdd90aae5fe39ab