### PR TITLE
Adjust skeletons and mobile list text

### DIFF
--- a/tech-farming-frontend/src/app/admin/components/admin-table.component.ts
+++ b/tech-farming-frontend/src/app/admin/components/admin-table.component.ts
@@ -48,7 +48,7 @@ interface Usuario {
         <ng-template #loadingRows>
           <tr *ngFor="let _ of skeletonArray">
             <td colspan="8">
-              <div class="skeleton h-6 w-full rounded bg-base-300 animate-pulse opacity-60"></div>
+              <div class="skeleton h-4 w-full rounded bg-base-300 animate-pulse opacity-40"></div>
             </td>
           </tr>
         </ng-template>

--- a/tech-farming-frontend/src/app/alertas/components/alert-card-list.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/alert-card-list.component.ts
@@ -17,7 +17,7 @@ import { Alerta } from '../models/index';
             </span>
           </div>
           <div class="text-sm">{{ a.sensor_nombre || '-' }} · {{ a.tipo_parametro || '-' }}</div>
-          <p class="text-sm">{{ a.mensaje }}</p>
+          <p class="text-xs">{{ a.mensaje }}</p>
           <div *ngIf="a.resuelta_por" class="text-xs text-base-content/60">Resuelta por {{ a.resuelta_por }}</div>
           <div class="text-right" *ngIf="showResolver">
             <button class="btn btn-outline btn-sm" (click)="resolver.emit(a)" [disabled]="resolviendoId === a.id">

--- a/tech-farming-frontend/src/app/alertas/components/alertas-activas.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/alertas-activas.component.ts
@@ -52,7 +52,7 @@ import { Alerta } from '../../models/index';
       <ng-template #loadingRows>
         <tr *ngFor="let _ of skeletonArray">
           <td colspan="6">
-            <div class="skeleton h-6 w-full rounded bg-base-300 animate-pulse opacity-60"></div>
+            <div class="skeleton h-4 w-full rounded bg-base-300 animate-pulse opacity-40"></div>
           </td>
         </tr>
       </ng-template>

--- a/tech-farming-frontend/src/app/alertas/components/alertas-historial.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/alertas-historial.component.ts
@@ -41,7 +41,7 @@ import { Alerta } from '../../models/index';
       <ng-template #loadingRows>
         <tr *ngFor="let _ of skeletonArray">
           <td colspan="6">
-            <div class="skeleton h-6 w-full rounded bg-base-300 animate-pulse opacity-60"></div>
+            <div class="skeleton h-4 w-full rounded bg-base-300 animate-pulse opacity-40"></div>
           </td>
         </tr>
       </ng-template>

--- a/tech-farming-frontend/src/app/invernaderos/components/invernadero-table.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/invernadero-table.component.ts
@@ -91,7 +91,7 @@ import { Invernadero } from '../models/invernadero.model';
         <ng-template #loadingRows>
           <tr *ngFor="let _ of skeletonArray" class="hover">
             <td colspan="6">
-              <div class="skeleton h-6 w-full rounded bg-base-300 animate-pulse opacity-60"></div>
+              <div class="skeleton h-4 w-full rounded bg-base-300 animate-pulse opacity-40"></div>
             </td>
           </tr>
         </ng-template>

--- a/tech-farming-frontend/src/app/invernaderos/components/view-invernadero.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/view-invernadero.component.ts
@@ -307,7 +307,7 @@ import { AlertService } from '../../alertas/alertas.service';
                   <tbody>
                     <tr *ngFor="let _ of skeletonArray" class="hover">
                       <td colspan="5">
-                        <div class="skeleton h-6 w-full rounded bg-base-300 animate-pulse opacity-60"></div>
+                        <div class="skeleton h-4 w-full rounded bg-base-300 animate-pulse opacity-40"></div>
                       </td>
                     </tr>
                   </tbody>
@@ -331,7 +331,7 @@ import { AlertService } from '../../alertas/alertas.service';
                 <li *ngFor="let z of zonasList; trackBy: trackByZona" class="py-4" role="listitem">
                   <div class="flex justify-between items-center">
                     <div>
-                      <p class="font-medium">{{ z.nombre }}</p>
+                      <p class="font-medium text-xs">{{ z.nombre }}</p>
                       <p class="text-xs text-base-content/60">
                         {{ z.creado_en | date:'short':'':'es' }}
                       </p>
@@ -379,8 +379,8 @@ import { AlertService } from '../../alertas/alertas.service';
                 <ul class="sm:hidden flex flex-col divide-y divide-base-200" role="list">
                   <li *ngFor="let _ of skeletonArray" class="py-4" role="listitem">
                     <div class="space-y-2">
-                      <div class="skeleton h-4 w-3/4 rounded bg-base-300 animate-pulse opacity-60"></div>
-                      <div class="skeleton h-4 w-1/2 rounded bg-base-300 animate-pulse opacity-60"></div>
+                      <div class="skeleton h-4 w-3/4 rounded bg-base-300 animate-pulse opacity-40"></div>
+                      <div class="skeleton h-4 w-1/2 rounded bg-base-300 animate-pulse opacity-40"></div>
                     </div>
                   </li>
                 </ul>
@@ -493,7 +493,7 @@ import { AlertService } from '../../alertas/alertas.service';
                   <tbody>
                     <tr *ngFor="let _ of skeletonArray" class="hover">
                       <td colspan="5">
-                        <div class="skeleton h-6 w-full rounded bg-base-300 animate-pulse opacity-60"></div>
+                        <div class="skeleton h-4 w-full rounded bg-base-300 animate-pulse opacity-40"></div>
                       </td>
                     </tr>
                   </tbody>
@@ -517,7 +517,7 @@ import { AlertService } from '../../alertas/alertas.service';
                 <li *ngFor="let s of sensoresPage.data; trackBy: trackBySensor" class="py-4" role="listitem">
                   <div class="flex justify-between items-center">
                     <div>
-                      <p class="font-medium">{{ s.nombre }}</p>
+                      <p class="font-medium text-xs">{{ s.nombre }}</p>
                       <p class="text-xs text-base-content/60">
                         {{ s.zona?.nombre || '—' }}
                       </p>
@@ -545,8 +545,8 @@ import { AlertService } from '../../alertas/alertas.service';
                 <ul class="sm:hidden flex flex-col divide-y divide-base-200" role="list">
                   <li *ngFor="let _ of skeletonArray" class="py-4" role="listitem">
                     <div class="space-y-2">
-                      <div class="skeleton h-4 w-3/4 rounded bg-base-300 animate-pulse opacity-60"></div>
-                      <div class="skeleton h-4 w-1/2 rounded bg-base-300 animate-pulse opacity-60"></div>
+                      <div class="skeleton h-4 w-3/4 rounded bg-base-300 animate-pulse opacity-40"></div>
+                      <div class="skeleton h-4 w-1/2 rounded bg-base-300 animate-pulse opacity-40"></div>
                     </div>
                   </li>
                 </ul>
@@ -678,7 +678,7 @@ import { AlertService } from '../../alertas/alertas.service';
                   <tbody>
                     <tr *ngFor="let _ of skeletonArray" class="hover">
                       <td colspan="5">
-                        <div class="skeleton h-6 w-full rounded bg-base-300 animate-pulse opacity-60"></div>
+                        <div class="skeleton h-4 w-full rounded bg-base-300 animate-pulse opacity-40"></div>
                       </td>
                     </tr>
                   </tbody>
@@ -702,7 +702,7 @@ import { AlertService } from '../../alertas/alertas.service';
                 <li *ngFor="let a of alertasPage.data; trackBy: trackByAlerta" class="py-4" role="listitem">
                   <div class="flex justify-between items-center">
                     <div>
-                      <p class="font-medium">{{ a.sensor_nombre }}</p>
+                      <p class="font-medium text-xs">{{ a.sensor_nombre }}</p>
                       <p class="text-xs text-base-content/60">
                         {{ a.fecha_hora | date:'short':'':'es' }}
                       </p>
@@ -737,8 +737,8 @@ import { AlertService } from '../../alertas/alertas.service';
                 <ul class="sm:hidden flex flex-col divide-y divide-base-200" role="list">
                   <li *ngFor="let _ of skeletonArray" class="py-4" role="listitem">
                     <div class="space-y-2">
-                      <div class="skeleton h-4 w-3/4 rounded bg-base-300 animate-pulse opacity-60"></div>
-                      <div class="skeleton h-4 w-1/2 rounded bg-base-300 animate-pulse opacity-60"></div>
+                      <div class="skeleton h-4 w-3/4 rounded bg-base-300 animate-pulse opacity-40"></div>
+                      <div class="skeleton h-4 w-1/2 rounded bg-base-300 animate-pulse opacity-40"></div>
                     </div>
                   </li>
                 </ul>

--- a/tech-farming-frontend/src/app/sensores/components/sensor-card.component.ts
+++ b/tech-farming-frontend/src/app/sensores/components/sensor-card.component.ts
@@ -27,7 +27,7 @@ import { SensorModalType } from '../sensor-modal.service';
           </span>
         </ng-container>
         <ng-template #loadingEstado>
-          <div class="skeleton h-4 w-24 rounded bg-base-300 animate-pulse opacity-60"></div>
+          <div class="skeleton h-4 w-24 rounded bg-base-300 animate-pulse opacity-40"></div>
         </ng-template>
       </div>
 
@@ -44,7 +44,7 @@ import { SensorModalType } from '../sensor-modal.service';
             <ng-template #noData><strong>Última:</strong> — sin datos —</ng-template>
           </ng-container>
           <ng-template #loadingLectura>
-            <div class="skeleton h-4 w-24 rounded bg-base-300 animate-pulse opacity-60"></div>
+          <div class="skeleton h-4 w-24 rounded bg-base-300 animate-pulse opacity-40"></div>
           </ng-template>
         </li>
       </ul>
@@ -63,7 +63,7 @@ import { SensorModalType } from '../sensor-modal.service';
 
       <ng-template #loadingValores>
         <div class="space-y-1 mb-4">
-          <div class="skeleton h-4 w-32 rounded bg-base-300 animate-pulse opacity-60"></div>
+          <div class="skeleton h-4 w-32 rounded bg-base-300 animate-pulse opacity-40"></div>
         </div>
       </ng-template>
 

--- a/tech-farming-frontend/src/app/sensores/components/sensor-table.component.ts
+++ b/tech-farming-frontend/src/app/sensores/components/sensor-table.component.ts
@@ -113,7 +113,7 @@ import { SensorModalType } from '../sensor-modal.service';
         <ng-template #loadingRows>
           <tr *ngFor="let _ of skeletonArray" class="hover">
             <td colspan="9">
-              <div class="skeleton h-6 w-full rounded bg-base-300 animate-pulse opacity-60"></div>
+              <div class="skeleton h-4 w-full rounded bg-base-300 animate-pulse opacity-40"></div>
             </td>
           </tr>
         </ng-template>


### PR DESCRIPTION
## Summary
- shrink skeleton blocks and use `opacity-40`
- tone down text in mobile lists

## Testing
- `npm test --silent` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_6848a67583a4832aab45b09c944e4792