### PR TITLE
Enable scrolling in mobile zone details

### DIFF
--- a/tech-farming-frontend/src/app/invernaderos/components/view-invernadero.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/view-invernadero.component.ts
@@ -367,7 +367,7 @@ import { AlertService } from '../../alertas/alertas.service';
                   </div>
                   <div
                     *ngIf="zonaExpandida === z.id"
-                    class="mt-2 bg-base-100 p-3 rounded-lg transition-max-height duration-200 ease-in-out"
+                    class="mt-2 bg-base-100 p-3 rounded-lg transition-max-height duration-200 ease-in-out max-h-[30vh] overflow-y-auto"
                   >
                     <p role="document"><strong>Descripción:</strong> {{ z.descripcion || '—' }}</p>
                     <p role="document"><strong>Sensores:</strong> {{ z.sensoresCount }}</p>


### PR DESCRIPTION
## Summary
- adjust the mobile zone detail container styles so expanded sections can scroll

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6848a66057d4832a8bc7e0fd91f1e9ae