### PR TITLE
Improve mobile styling for general section

### DIFF
--- a/tech-farming-frontend/src/app/invernaderos/components/view-invernadero.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/view-invernadero.component.ts
@@ -107,7 +107,7 @@ import { AlertService } from '../../alertas/alertas.service';
           id="seccion-general"
           class="snap-section h-full flex flex-col justify-start items-center px-4 lg:px-20"
         >
-          <div class="max-w-4xl w-full bg-base-100 rounded-2xl p-8 space-y-6">
+          <div class="max-w-4xl w-full bg-base-100 rounded-2xl p-8 space-y-5 sm:space-y-3">
             <h2
               id="titulo-invernadero"
               class="text-3xl font-extrabold text-success text-center"
@@ -125,11 +125,11 @@ import { AlertService } from '../../alertas/alertas.service';
   
             <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6">
               <!-- CARD 1: Zonas -->
-              <div class="card bg-base-200 p-6 rounded-2xl shadow flex-1 flex flex-col items-center justify-center min-h-[120px]">
+              <div class="card bg-base-200 rounded-xl shadow p-6 lg:p-6 md:p-5 sm:p-4 flex flex-col items-center justify-center min-h-[110px] sm:min-h-[90px]">
                 <!-- Ícono “Pin” -->
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  class="w-7 h-7 text-info"
+                  class="w-7 h-7 sm:w-6 sm:h-6 text-info"
                   fill="currentColor"
                   viewBox="0 0 20 20"
                   aria-hidden="true"
@@ -140,21 +140,21 @@ import { AlertService } from '../../alertas/alertas.service';
                     clip-rule="evenodd"
                   />
                 </svg>
-                <span class="mt-2 text-xl font-semibold">
+                <span class="mt-1 text-lg sm:text-base font-semibold">
                   {{ resumenDelete?.zonasCount }}
                   Zona{{ resumenDelete?.zonasCount === 1 ? '' : 's' }}
                 </span>
-                <span class="text-sm text-base-content/60">
+                <span class="text-xs sm:text-[11px] text-base-content/60">
                   Activa{{ resumenDelete?.zonasCount === 1 ? '' : 's' }}
                 </span>
               </div>
   
               <!-- CARD 2: Sensores -->
-              <div class="card bg-base-200 p-6 rounded-2xl shadow flex-1 flex flex-col items-center justify-center min-h-[120px]">
+              <div class="card bg-base-200 rounded-xl shadow p-6 lg:p-6 md:p-5 sm:p-4 flex flex-col items-center justify-center min-h-[110px] sm:min-h-[90px]">
                 <!-- Ícono “Termómetro” -->
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  class="w-7 h-7 text-accent"
+                  class="w-7 h-7 sm:w-6 sm:h-6 text-accent"
                   fill="currentColor"
                   viewBox="0 0 20 20"
                   aria-hidden="true"
@@ -165,21 +165,21 @@ import { AlertService } from '../../alertas/alertas.service';
                     clip-rule="evenodd"
                   />
                 </svg>
-                <span class="mt-2 text-xl font-semibold">
+                <span class="mt-1 text-lg sm:text-base font-semibold">
                   {{ resumenDelete?.sensoresCount }}
                   Sensor{{ resumenDelete?.sensoresCount === 1 ? '' : 'es' }}
                 </span>
-                <span class="text-sm text-base-content/60">
+                <span class="text-xs sm:text-[11px] text-base-content/60">
                   Registrado{{ resumenDelete?.sensoresCount === 1 ? '' : 's' }}
                 </span>
               </div>
   
               <!-- CARD 3: Alertas -->
-              <div class="card bg-base-200 p-6 rounded-2xl shadow flex-1 flex flex-col items-center justify-center min-h-[120px]">
+              <div class="card bg-base-200 rounded-xl shadow p-6 lg:p-6 md:p-5 sm:p-4 flex flex-col items-center justify-center min-h-[110px] sm:min-h-[90px]">
                 <!-- Ícono “Campana” -->
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  class="w-7 h-7 text-error"
+                  class="w-7 h-7 sm:w-6 sm:h-6 text-error"
                   fill="currentColor"
                   viewBox="0 0 20 20"
                   aria-hidden="true"
@@ -188,17 +188,17 @@ import { AlertService } from '../../alertas/alertas.service';
                     d="M10 2a6 6 0 00-6 6v3.586l-1.707 1.707A1 1 0 004 15h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zm-2 14a2 2 0 104 0H8z"
                   />
                 </svg>
-                <span class="mt-2 text-xl font-semibold">
+                <span class="mt-1 text-lg sm:text-base font-semibold">
                   {{ resumenDelete?.alertasActivasCount || 0 }}
                   Alerta{{ (resumenDelete?.alertasActivasCount || 0) === 1 ? '' : 's' }}
                 </span>
-                <span class="text-sm text-base-content/60">
+                <span class="text-xs sm:text-[11px] text-base-content/60">
                   Activa{{ (resumenDelete?.alertasActivasCount || 0) === 1 ? '' : 's' }}
                 </span>
               </div>
             </div>
   
-            <div class="bg-base-100 p-6 rounded-lg shadow-md mt-8">
+            <div class="bg-base-200 rounded-lg p-4 mb-6">
               <h3 class="text-2xl font-bold mb-4">Detalles del Invernadero</h3>
               <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
                 <ul class="space-y-2">
@@ -323,7 +323,7 @@ import { AlertService } from '../../alertas/alertas.service';
               <!-- Lista Mobile -->
               <ul
                 *ngIf="!isLoadingZonas && zonasList.length; else listZonasSkeleton"
-                class="sm:hidden flex flex-col divide-y divide-base-200"
+                class="sm:hidden flex flex-col divide-y divide-base-300"
                 role="list"
               >
                 <li *ngFor="let z of zonasList; trackBy: trackByZona" class="py-4" role="listitem">
@@ -374,7 +374,7 @@ import { AlertService } from '../../alertas/alertas.service';
               </ul>
 
               <ng-template #listZonasSkeleton>
-                <ul class="sm:hidden flex flex-col divide-y divide-base-200" role="list">
+                <ul class="sm:hidden flex flex-col divide-y divide-base-300" role="list">
                   <li *ngFor="let _ of skeletonArray" class="py-4" role="listitem">
                     <div class="space-y-2">
                       <div class="skeleton h-4 w-3/4 rounded bg-base-300 animate-pulse opacity-40"></div>
@@ -509,13 +509,13 @@ import { AlertService } from '../../alertas/alertas.service';
               <!-- Lista Mobile -->
               <ul
                 *ngIf="!isLoadingSensores && sensoresPage.data.length; else listSkeleton"
-                class="sm:hidden flex flex-col divide-y divide-base-200"
+                class="sm:hidden flex flex-col divide-y divide-base-300"
                 role="list"
               >
                 <li *ngFor="let s of sensoresPage.data; trackBy: trackBySensor" class="py-4" role="listitem">
                   <div class="flex justify-between items-center">
                     <div>
-                      <p class="font-medium text-xs">{{ s.nombre }}</p>
+                      <p class="font-medium text-xs truncate max-w-[90%]">{{ s.nombre }}</p>
                       <p class="text-xs text-base-content/60">
                         {{ s.zona?.nombre || '—' }}
                       </p>
@@ -540,7 +540,7 @@ import { AlertService } from '../../alertas/alertas.service';
               </ul>
 
               <ng-template #listSkeleton>
-                <ul class="sm:hidden flex flex-col divide-y divide-base-200" role="list">
+                <ul class="sm:hidden flex flex-col divide-y divide-base-300" role="list">
                   <li *ngFor="let _ of skeletonArray" class="py-4" role="listitem">
                     <div class="space-y-2">
                       <div class="skeleton h-4 w-3/4 rounded bg-base-300 animate-pulse opacity-40"></div>
@@ -566,7 +566,7 @@ import { AlertService } from '../../alertas/alertas.service';
             >
               <button
                 type="button"
-                class="btn btn-sm btn-outline"
+                class="btn btn-xs btn-outline"
                 [disabled]="sensoresPageIndex === 1 || isLoadingSensores"
                 (click)="cambiarPagina('sensores', -1)"
                 [attr.aria-label]="'Página anterior de sensores'"
@@ -581,12 +581,12 @@ import { AlertService } from '../../alertas/alertas.service';
                   />
                 </svg>
               </button>
-              <span class="px-2" aria-live="polite">
+              <span class="px-2 text-sm" aria-live="polite">
                 Página {{ sensoresPageIndex }} de {{ totalPagSensores }}
               </span>
               <button
                 type="button"
-                class="btn btn-sm btn-outline"
+                class="btn btn-xs btn-outline"
                 [disabled]="sensoresPageIndex === totalPagSensores || isLoadingSensores"
                 (click)="cambiarPagina('sensores', +1)"
                 [attr.aria-label]="'Página siguiente de sensores'"
@@ -694,13 +694,13 @@ import { AlertService } from '../../alertas/alertas.service';
               <!-- Lista Mobile -->
               <ul
                 *ngIf="!isLoadingAlertas && alertasPage.data.length; else listAlertasSkeleton"
-                class="sm:hidden flex flex-col divide-y divide-base-200"
+                class="sm:hidden flex flex-col divide-y divide-base-300"
                 role="list"
               >
                 <li *ngFor="let a of alertasPage.data; trackBy: trackByAlerta" class="py-4" role="listitem">
                   <div class="flex justify-between items-center">
                     <div>
-                      <p class="font-medium text-xs">{{ a.sensor_nombre }}</p>
+                      <p class="font-medium text-xs truncate max-w-[90%]">{{ a.sensor_nombre }}</p>
                       <p class="text-xs text-base-content/60">
                         {{ a.fecha_hora | date:'short':'':'es' }}
                       </p>
@@ -732,7 +732,7 @@ import { AlertService } from '../../alertas/alertas.service';
               </ul>
 
               <ng-template #listAlertasSkeleton>
-                <ul class="sm:hidden flex flex-col divide-y divide-base-200" role="list">
+                <ul class="sm:hidden flex flex-col divide-y divide-base-300" role="list">
                   <li *ngFor="let _ of skeletonArray" class="py-4" role="listitem">
                     <div class="space-y-2">
                       <div class="skeleton h-4 w-3/4 rounded bg-base-300 animate-pulse opacity-40"></div>
@@ -758,7 +758,7 @@ import { AlertService } from '../../alertas/alertas.service';
             >
               <button
                 type="button"
-                class="btn btn-sm btn-outline"
+                class="btn btn-xs btn-outline"
                 [disabled]="alertasPageIndex === 1 || isLoadingAlertas"
                 (click)="cambiarPagina('alertas', -1)"
                 [attr.aria-label]="'Página anterior de alertas'"
@@ -773,12 +773,12 @@ import { AlertService } from '../../alertas/alertas.service';
                   />
                 </svg>
               </button>
-              <span class="px-2" aria-live="polite">
+              <span class="px-2 text-sm" aria-live="polite">
                 Página {{ alertasPageIndex }} de {{ totalPagAlertas }}
               </span>
               <button
                 type="button"
-                class="btn btn-sm btn-outline"
+                class="btn btn-xs btn-outline"
                 [disabled]="alertasPageIndex === totalPagAlertas || isLoadingAlertas"
                 (click)="cambiarPagina('alertas', +1)"
                 [attr.aria-label]="'Página siguiente de alertas'"
@@ -1151,8 +1151,6 @@ import { AlertService } from '../../alertas/alertas.service';
         /* ================= scroll-snap container y secciones ================= */
         .snap-container {
           scroll-snap-type: y mandatory;
-          height: 100vh;
-          overflow-y: hidden;      /* Deshabilitar scroll manual */
           scrollbar-width: none;
         }
         .snap-container::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- allow scrolling on mobile with full viewport height
- adjust general section cards for smaller screens
- tweak typography and card spacing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test` in frontend *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6848a597e35c832aa8882e67c6c8e4f6