### PR TITLE
Improve umbral list responsiveness

### DIFF
--- a/tech-farming-frontend/src/app/alertas/components/umbral-config-modal.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/umbral-config-modal.component.ts
@@ -28,6 +28,15 @@ import { Sensor } from '../../sensores/models/sensor.model';
       </div>
     </div>
 
+    <!-- Modal de Error -->
+    <div *ngIf="errorVisible" class="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
+      <div class="bg-base-100 p-6 rounded-xl shadow-xl text-center w-[90vw] max-w-xs sm:max-w-sm space-y-2 border border-base-300">
+        <h3 class="text-xl font-semibold text-error">❌ Error</h3>
+        <p>{{ mensajeError }}</p>
+        <button class="btn btn-sm btn-outline mt-3" (click)="errorVisible = false">Cerrar</button>
+      </div>
+    </div>
+
     <!-- Modal de Ayuda -->
     <div *ngIf="ayudaVisible"
         class="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
@@ -224,6 +233,8 @@ export class UmbralConfigModalComponent implements OnInit, OnDestroy {
   ayudaVisible = false;
   confirmacionVisible = false;
   mensajeConfirmacion = '';
+  errorVisible = false;
+  mensajeError = '';
 
   private formSub?: Subscription;
   private ambitoSub?: Subscription;
@@ -486,8 +497,10 @@ export class UmbralConfigModalComponent implements OnInit, OnDestroy {
           this.modal.closeWithAnimation();
         }, 2500);
       },
-      error: () => {
+      error: (err) => {
         this.loading = false;
+        this.mensajeError = err?.error?.error || 'No se pudo crear el umbral.';
+        this.errorVisible = true;
       }
     });
   }

--- a/tech-farming-frontend/src/app/alertas/components/umbral-list.component.ts
+++ b/tech-farming-frontend/src/app/alertas/components/umbral-list.component.ts
@@ -37,65 +37,94 @@ import { FormsModule } from '@angular/forms';
         <button class="btn btn-ghost" (click)="modal.closeModal()">✕</button>
       </div>
 
-      <!-- Tabs -->
-      <div class="flex justify-between items-center mb-4">
-        <div class="tabs">
-          <a *ngFor="let t of scopes; let i = index" class="tab tab-lg" [class.tab-active]="scopeIndex === i" (click)="switchScope(i)">
+      <!-- Tabs + CTA -->
+      <div class="mb-4 flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+        <div class="tabs tabs-boxed overflow-x-auto whitespace-nowrap">
+          <a
+            *ngFor="let t of scopes; let i = index"
+            class="tab tab-sm md:tab-lg"
+            [class.tab-active]="scopeIndex === i"
+            (click)="switchScope(i)"
+          >
             {{ t | titlecase }}
           </a>
         </div>
         <button
           *ngIf="puedeCrear"
-          class="btn bg-transparent border-success text-base-content hover:bg-success hover:text-success-content"
+          class="btn btn-success md:btn-outline w-full md:w-auto"
           (click)="nuevoUmbral(); $event.stopPropagation()"
         >
           + Nuevo Umbral
         </button>
       </div>
 
-      <!-- Tabla -->
-      <table class="table w-full">
-        <thead>
-          <tr>
-            <th>Parámetro</th>
-            <th *ngIf="scopes[scopeIndex] === 'invernadero'">Invernadero</th>
-            <th *ngIf="scopes[scopeIndex] === 'sensor'">Invernadero</th>
-            <th *ngIf="scopes[scopeIndex] === 'sensor'">Sensor</th>
-            <th>Advertencia</th>
-            <th>Crítico</th>
-            <th class="text-right">Acciones</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let u of umbrales">
-            <td>{{ u.tipo_parametro_nombre }} ({{ u.tipo_parametro_unidad }})</td>
-            <td *ngIf="scopes[scopeIndex] === 'invernadero'">{{ u.invernadero_nombre }}</td>
-            <td *ngIf="scopes[scopeIndex] === 'sensor'">{{ u.sensor_invernadero_nombre }}</td>
-            <td *ngIf="scopes[scopeIndex] === 'sensor'">{{ u.sensor_nombre }}</td>
-            <td>{{ u.advertencia_min }} – {{ u.advertencia_max }}</td>
-            <td>{{ u.critico_min || '-' }} – {{ u.critico_max || '-' }}</td>
-            <td class="text-right">
-              <button *ngIf="puedeEditar" class="btn btn-sm btn-outline mr-2" (click)="editar(u); $event.stopPropagation()">✏️</button>
-              <button *ngIf="puedeEliminar" class="btn btn-sm btn-error" (click)="eliminar(u)">🗑️</button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <!-- Tabla (escritorio) -->
+      <div class="overflow-x-auto hidden md:block">
+        <table class="table w-full">
+          <thead>
+            <tr>
+              <th>Parámetro</th>
+              <th *ngIf="scopes[scopeIndex] === 'invernadero'">Invernadero</th>
+              <th *ngIf="scopes[scopeIndex] === 'sensor'">Invernadero</th>
+              <th *ngIf="scopes[scopeIndex] === 'sensor'">Sensor</th>
+              <th>Advertencia</th>
+              <th>Crítico</th>
+              <th class="text-right">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let u of umbrales">
+              <td>{{ u.tipo_parametro_nombre }} ({{ u.tipo_parametro_unidad }})</td>
+              <td *ngIf="scopes[scopeIndex] === 'invernadero'">{{ u.invernadero_nombre }}</td>
+              <td *ngIf="scopes[scopeIndex] === 'sensor'">{{ u.sensor_invernadero_nombre }}</td>
+              <td *ngIf="scopes[scopeIndex] === 'sensor'">{{ u.sensor_nombre }}</td>
+              <td>{{ u.advertencia_min }} – {{ u.advertencia_max }}</td>
+              <td>{{ u.critico_min || '-' }} – {{ u.critico_max || '-' }}</td>
+              <td class="text-right">
+                <button *ngIf="puedeEditar" class="btn btn-sm btn-outline mr-2" (click)="editar(u); $event.stopPropagation()">✏️</button>
+                <button *ngIf="puedeEliminar" class="btn btn-sm btn-error" (click)="eliminar(u)">🗑️</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Tarjetas (móvil) -->
+      <div class="flex flex-col space-y-4 md:hidden">
+        <div *ngFor="let u of umbrales" class="card bg-base-100 shadow p-4 space-y-1">
+          <h3 class="font-semibold">
+            {{ u.tipo_parametro_nombre }} ({{ u.tipo_parametro_unidad }})
+          </h3>
+          <div *ngIf="scopes[scopeIndex] === 'invernadero'" class="text-sm">
+            <strong>Invernadero:</strong> {{ u.invernadero_nombre }}
+          </div>
+          <div *ngIf="scopes[scopeIndex] === 'sensor'" class="text-sm space-y-1">
+            <div><strong>Invernadero:</strong> {{ u.sensor_invernadero_nombre }}</div>
+            <div><strong>Sensor:</strong> {{ u.sensor_nombre }}</div>
+          </div>
+          <div class="text-sm"><strong>Advertencia:</strong> {{ u.advertencia_min }} – {{ u.advertencia_max }}</div>
+          <div class="text-sm"><strong>Crítico:</strong> {{ u.critico_min || '-' }} – {{ u.critico_max || '-' }}</div>
+          <div class="flex justify-end gap-2 pt-2">
+            <button *ngIf="puedeEditar" class="btn btn-sm btn-outline" (click)="editar(u); $event.stopPropagation()">✏️</button>
+            <button *ngIf="puedeEliminar" class="btn btn-sm btn-error" (click)="eliminar(u)">🗑️</button>
+          </div>
+        </div>
+      </div>
 
       <!-- Paginación -->
-      <div class="flex items-center justify-between p-6 bg-base-200 rounded-lg mt-6" *ngIf="totalPages >= 0">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 p-6 bg-base-200 rounded-lg mt-6" *ngIf="totalPages >= 0">
         <div class="text-sm text-base-content/70">
           Página {{ totalPages === 0 ? 0 : currentPage }} de {{ totalPages }} · {{ totalUmbrales }} umbral{{ totalUmbrales !== 1 ? 'es' : '' }}
         </div>
 
-        <div class="flex items-center gap-2" *ngIf="totalPages > 1">
-          <button class="btn btn-sm btn-outline rounded-full" (click)="goToPage(1)" [disabled]="currentPage === 1">«</button>
-          <button class="btn btn-sm btn-outline rounded-full" (click)="goToPage(currentPage - 1)" [disabled]="currentPage === 1">‹</button>
+        <div class="flex items-center gap-2 overflow-x-auto whitespace-nowrap md:overflow-visible" *ngIf="totalPages > 1">
+          <button class="btn btn-xs md:btn-sm btn-outline rounded-full" (click)="goToPage(1)" [disabled]="currentPage === 1">«</button>
+          <button class="btn btn-xs md:btn-sm btn-outline rounded-full" (click)="goToPage(currentPage - 1)" [disabled]="currentPage === 1">‹</button>
 
           <ng-container *ngFor="let item of paginationItems()">
             <ng-container *ngIf="item !== '…'; else dots">
               <button
-                class="btn btn-sm rounded-full"
+                class="btn btn-xs md:btn-sm rounded-full"
                 [ngClass]="{
                   'btn-success text-base-content border-success cursor-default': item === currentPage,
                   'btn-outline': item !== currentPage
@@ -109,8 +138,8 @@ import { FormsModule } from '@angular/forms';
             </ng-template>
           </ng-container>
 
-          <button class="btn btn-sm btn-outline rounded-full" (click)="goToPage(currentPage + 1)" [disabled]="currentPage === totalPages">›</button>
-          <button class="btn btn-sm btn-outline rounded-full" (click)="goToPage(totalPages)" [disabled]="currentPage === totalPages">»</button>
+          <button class="btn btn-xs md:btn-sm btn-outline rounded-full" (click)="goToPage(currentPage + 1)" [disabled]="currentPage === totalPages">›</button>
+          <button class="btn btn-xs md:btn-sm btn-outline rounded-full" (click)="goToPage(totalPages)" [disabled]="currentPage === totalPages">»</button>
         </div>
       </div>
     </div>
@@ -143,6 +172,9 @@ export class UmbralListComponent implements OnInit {
   ) { }
 
   async ngOnInit() {
+    if (window.innerWidth < 768) {
+      this.pageSize = 2;
+    }
     // Obtener sesión activa
     const session = await this.supaSvc.supabase.auth.getSession();
     const user = session.data?.session?.user;


### PR DESCRIPTION
## Summary
- make scope tabs scrollable and move the CTA button below in mobile
- use vertical card list for mobile with extra spacing
- shrink pagination buttons for small screens and allow overflow scrolling
- limit page size to 2 items on mobile

## Testing
- `npm test --silent --unsafe-perm` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6848cd1a0944832a86337926e0a08339