### PR TITLE
Fix button style in history filters

### DIFF
--- a/tech-farming-frontend/src/app/historial/components/filtro.component.ts
+++ b/tech-farming-frontend/src/app/historial/components/filtro.component.ts
@@ -184,10 +184,10 @@ import { Subscription } from 'rxjs';
         <div></div>
 
         <!-- Botón “Aplicar filtros” alineado a derecha -->
-        <div class="text-right">
+        <div class="flex justify-end sm:justify-start">
           <button
             type="button"
-            class="btn btn-primary"
+            class="btn btn-outline btn-sm h-10 w-full sm:w-auto border-success text-base-content hover:bg-success hover:text-base-content transition-colors duration-200"
             (click)="aplicarFiltros()"
             [disabled]="form.invalid"
           >


### PR DESCRIPTION
## Summary
- update style for 'Aplicar filtros' button to match filter styles

## Testing
- `npm test --prefix tech-farming-frontend` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6848fe9e464c832a9e29451b2867e760