### PR TITLE
Add admin authentication decorator with tests

### DIFF
--- a/tech-farming-backend/app/routes/usuarios.py
+++ b/tech-farming-backend/app/routes/usuarios.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, request, jsonify
+from app.utils.auth_supabase import admin_requerido
 from app import db
 from app.models.usuario import Usuario
 from app.models.usuario_permiso import UsuarioPermiso
@@ -48,6 +49,7 @@ def crear_usuario_desde_supabase():
     return jsonify({"mensaje": "Usuario y permisos creados correctamente"}), 201
 
 @router.route('/trabajadores', methods=['POST'])
+@admin_requerido
 def invitar_usuario():
     data = request.get_json()
 
@@ -96,6 +98,7 @@ def invitar_usuario():
     return jsonify({"mensaje": "Usuario invitado y registrado correctamente"}), 201
 
 @router.route('/trabajadores', methods=['GET'])
+@admin_requerido
 def listar_trabajadores():
     trabajadores = Usuario.query.join(Rol).filter(Rol.nombre == 'Trabajador').all()
     resultado = []
@@ -114,6 +117,7 @@ def listar_trabajadores():
     return jsonify(resultado), 200
 
 @router.route('/trabajadores/<int:usuario_id>', methods=['PATCH'])
+@admin_requerido
 def actualizar_permisos(usuario_id):
     data = request.get_json()
     permisos = UsuarioPermiso.query.filter_by(usuario_id=usuario_id).first()

--- a/tech-farming-backend/app/utils/auth_supabase.py
+++ b/tech-farming-backend/app/utils/auth_supabase.py
@@ -45,3 +45,19 @@ def usuario_autenticado_requerido(f):
             return jsonify({"error": str(e)}), 401
 
     return decorated_function
+
+
+def admin_requerido(f):
+    """Decorator que garantiza que el usuario es administrador."""
+
+    @usuario_autenticado_requerido
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if getattr(g.usuario, "rol_id", None) != 1:
+            return (
+                jsonify({"error": "Usuario sin privilegios de administrador"}),
+                403,
+            )
+        return f(*args, **kwargs)
+
+    return decorated_function

--- a/tech-farming-backend/tests/test_admin_required.py
+++ b/tech-farming-backend/tests/test_admin_required.py
@@ -1,0 +1,53 @@
+import types
+import importlib
+import importlib.util
+import os
+
+from flask import Flask
+import pytest
+
+from app.utils import auth_supabase
+
+class DummySupabase:
+    def __init__(self):
+        class Admin:
+            def invite_user_by_email(self, email, data):
+                return types.SimpleNamespace(user=types.SimpleNamespace(id="1"))
+        class Auth:
+            def __init__(self):
+                self.admin = Admin()
+        self.auth = Auth()
+
+def load_usuarios(monkeypatch):
+    monkeypatch.setattr(auth_supabase, "supabase", DummySupabase())
+    monkeypatch.setattr("supabase.create_client", lambda u, k: DummySupabase(), raising=False)
+    path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "app", "routes", "usuarios.py")
+    spec = importlib.util.spec_from_file_location("usuarios", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+@pytest.fixture
+def non_admin(monkeypatch):
+    user = types.SimpleNamespace(rol_id=2)
+    perms = types.SimpleNamespace()
+    monkeypatch.setattr(auth_supabase, "obtener_usuario_y_permisos", lambda: (user, perms))
+    return user
+
+@pytest.fixture
+def app_ctx():
+    app = Flask(__name__)
+    ctx = app.test_request_context("/")
+    ctx.push()
+    yield ctx
+    ctx.pop()
+
+@pytest.mark.parametrize("func_name", ["invitar_usuario", "listar_trabajadores", "actualizar_permisos"])
+def test_admin_endpoints_forbidden(non_admin, app_ctx, monkeypatch, func_name):
+    usuarios = load_usuarios(monkeypatch)
+    func = getattr(usuarios, func_name)
+    if func_name == "actualizar_permisos":
+        response = func(1)
+    else:
+        response = func()
+    assert response[1] == 403


### PR DESCRIPTION
## Summary
- enforce admin-only access by creating `admin_requerido` decorator
- apply admin check to user-management endpoints
- add regression tests for admin protected endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684922a03e40832a8ba9cf6271e32fa5