### PR TITLE
Refactor predictions header into reusable component

### DIFF
--- a/tech-farming-frontend/src/app/predicciones/components/predicciones-header.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/components/predicciones-header.component.ts
@@ -1,0 +1,28 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-predicciones-header',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 my-5 mx-6">
+      <h1 class="text-4xl font-bold text-success tracking-tight">Predicciones</h1>
+      <div class="flex flex-col sm:flex-row gap-2">
+        <button
+          class="btn bg-transparent border-success text-base-content hover:bg-success hover:text-success-content flex items-center gap-2"
+          (click)="reload.emit()"
+          [disabled]="disabled"
+          aria-label="Actualizar predicciones"
+        >
+          <i class="fas fa-sync-alt"></i>
+          <span>Actualizar</span>
+        </button>
+      </div>
+    </div>
+  `
+})
+export class PrediccionesHeaderComponent {
+  @Input() disabled = false;
+  @Output() reload = new EventEmitter<void>();
+}

--- a/tech-farming-frontend/src/app/predicciones/predicciones.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/predicciones.component.ts
@@ -5,9 +5,6 @@ import { CommonModule }      from '@angular/common';
 import { FormsModule }       from '@angular/forms';
 import { HttpClientModule }  from '@angular/common/http';
 
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule }    from '@angular/material/select';
-import { MatButtonModule }    from '@angular/material/button';
 
 import { PrediccionesService } from './predicciones.service';
 import {
@@ -23,6 +20,7 @@ import { FiltroSelectComponent }    from '../historial/components/filtro-select.
 import { PredictionChartComponent } from './components/prediction-chart.component';
 import { SummaryCardComponent }     from './components/summary-card.component';
 import { Trend as UITrend, TrendCardComponent } from './components/trend-card.component';
+import { PrediccionesHeaderComponent } from './components/predicciones-header.component';
 
 @Component({
   selector: 'app-predicciones',
@@ -31,9 +29,7 @@ import { Trend as UITrend, TrendCardComponent } from './components/trend-card.co
     CommonModule,
     FormsModule,
     HttpClientModule,
-    MatFormFieldModule,
-    MatSelectModule,
-    MatButtonModule,
+    PrediccionesHeaderComponent,
     FiltroSelectComponent,
     PredictionChartComponent,
     SummaryCardComponent,
@@ -42,18 +38,10 @@ import { Trend as UITrend, TrendCardComponent } from './components/trend-card.co
   template: `
     <div class="flex flex-col" style="height: calc(100vh - var(--header-height));">
       <!-- HEADER -->
-      <div class="flex items-center justify-between px-6 py-4 bg-base-200 border-b border-base-300">
-        <h1 class="text-3xl font-bold text-base-content">Predicciones</h1>
-        <button
-          mat-stroked-button
-          color="primary"
-          (click)="reload()"
-          [disabled]="!selectedInvernadero"
-          class="btn btn-sm btn-outline"
-        >
-          <i class="fas fa-sync-alt mr-2"></i> Actualizar
-        </button>
-      </div>
+      <app-predicciones-header
+        (reload)="reload()"
+        [disabled]="!selectedInvernadero"
+      ></app-predicciones-header>
 
       <div class="flex-1 overflow-y-auto p-6 space-y-6 bg-base-200">
         <div *ngIf="showNoDataMsg" class="alert alert-warning mb-4">


### PR DESCRIPTION
## Summary
- create standalone `PrediccionesHeaderComponent`
- use the new header component in `PrediccionesComponent`

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684a59a63484832aa3f7c6ebb8e15140