### PR TITLE
Refactor predictions header, auto-reload

### DIFF
--- a/tech-farming-frontend/src/app/predicciones/components/predicciones-header.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/components/predicciones-header.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-predicciones-header',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 my-5 mx-6">
+      <h1 class="text-4xl font-bold text-success tracking-tight">Predicciones</h1>
+    </div>
+  `
+})
+export class PrediccionesHeaderComponent {}

--- a/tech-farming-frontend/src/app/predicciones/predicciones.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/predicciones.component.ts
@@ -5,9 +5,6 @@ import { CommonModule }      from '@angular/common';
 import { FormsModule }       from '@angular/forms';
 import { HttpClientModule }  from '@angular/common/http';
 
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule }    from '@angular/material/select';
-import { MatButtonModule }    from '@angular/material/button';
 
 import { PrediccionesService } from './predicciones.service';
 import {
@@ -23,6 +20,7 @@ import { FiltroSelectComponent }    from '../historial/components/filtro-select.
 import { PredictionChartComponent } from './components/prediction-chart.component';
 import { SummaryCardComponent }     from './components/summary-card.component';
 import { Trend as UITrend, TrendCardComponent } from './components/trend-card.component';
+import { PrediccionesHeaderComponent } from './components/predicciones-header.component';
 
 @Component({
   selector: 'app-predicciones',
@@ -31,9 +29,7 @@ import { Trend as UITrend, TrendCardComponent } from './components/trend-card.co
     CommonModule,
     FormsModule,
     HttpClientModule,
-    MatFormFieldModule,
-    MatSelectModule,
-    MatButtonModule,
+    PrediccionesHeaderComponent,
     FiltroSelectComponent,
     PredictionChartComponent,
     SummaryCardComponent,
@@ -42,18 +38,7 @@ import { Trend as UITrend, TrendCardComponent } from './components/trend-card.co
   template: `
     <div class="flex flex-col" style="height: calc(100vh - var(--header-height));">
       <!-- HEADER -->
-      <div class="flex items-center justify-between px-6 py-4 bg-base-200 border-b border-base-300">
-        <h1 class="text-3xl font-bold text-base-content">Predicciones</h1>
-        <button
-          mat-stroked-button
-          color="primary"
-          (click)="reload()"
-          [disabled]="!selectedInvernadero"
-          class="btn btn-sm btn-outline"
-        >
-          <i class="fas fa-sync-alt mr-2"></i> Actualizar
-        </button>
-      </div>
+      <app-predicciones-header></app-predicciones-header>
 
       <div class="flex-1 overflow-y-auto p-6 space-y-6 bg-base-200">
         <div *ngIf="showNoDataMsg" class="alert alert-warning mb-4">
@@ -183,18 +168,21 @@ export class PrediccionesComponent implements OnInit {
     this.svc.getZonasByInvernadero(idNum).subscribe(list => {
       this.zonas   = list;
       this.optZona = list.map(z => ({ id: z.id, label: z.nombre }));
+      this.reload();
     });
   }
 
   onZonaChange(id: string|number|undefined) {
     const idNum = id == null ? undefined : (typeof id === 'string' ? +id : id);
     this.selectedZona = idNum;
+    this.reload();
   }
 
   onParametroChange(param: string|number|undefined) {
     // forzamos a string, ignoramos valores no-string
     if (typeof param === 'string') {
       this.selectedParametro = param;
+      this.reload();
     }
   }
 
@@ -202,6 +190,7 @@ export class PrediccionesComponent implements OnInit {
     const hNum = h == null ? undefined : (typeof h === 'string' ? +h : h);
     if (hNum != null) {
       this.selectedProjection = hNum as 6|12|24;
+      this.reload();
     }
   }
 
@@ -237,7 +226,12 @@ export class PrediccionesComponent implements OnInit {
           return;
         }
 
-        this.data = res;
+        // filtrar predicciones según la proyección solicitada
+        let sliceUntil = 1;
+        if (this.selectedProjection === 12) sliceUntil = 2;
+        if (this.selectedProjection === 24) sliceUntil = 3;
+
+        this.data = { ...res, future: res.future.slice(0, sliceUntil) };
         this.uiTrend = this.mapTrend(res.trend);
 
         // construir summary enriquecido


### PR DESCRIPTION
## Summary
- drop update button from predictions header
- reload predictions automatically when filters change
- slice future predictions based on selected projection

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_684a59a63484832aa3f7c6ebb8e15140