### PR TITLE
Improve design for prediction cards

### DIFF
--- a/tech-farming-frontend/src/app/predicciones/components/summary-card.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/components/summary-card.component.ts
@@ -2,18 +2,25 @@
 
 import { Component, Input } from '@angular/core';
 import { CommonModule }      from '@angular/common';
-import { MatCardModule }     from '@angular/material/card';
 import { Summary }           from '../../models';
 
 @Component({
   selector: 'app-summary-card',
   standalone: true,
-  imports: [CommonModule, MatCardModule],
+  imports: [CommonModule],
   template: `
-    <mat-card class="summary-card h-full bg-base-100 p-6 rounded-lg shadow-sm flex flex-col">
+    <div
+      class="summary-card card relative overflow-hidden h-full bg-base-100 p-6 rounded-xl shadow-sm flex flex-col hover:shadow-md hover:-translate-y-1 transition"
+    >
+      <div class="absolute inset-0 bg-gradient-to-br from-primary/5 to-secondary/5 pointer-events-none"></div>
+
       <ng-container *ngIf="summary; else noSummaryTpl">
-        <h2 class="text-xl font-semibold mb-4">Resumen Predictivo</h2>
-        <div class="flex-1 space-y-2">
+        <div class="relative z-10 flex items-center mb-4">
+          <i class="fas fa-chart-bar text-accent text-2xl mr-2"></i>
+          <h2 class="text-xl font-semibold">Resumen Predictivo</h2>
+        </div>
+
+        <div class="relative z-10 flex-1 space-y-2">
           <p>
             <strong>Última medida:</strong>
             {{ summary.lastValue != null ? summary.lastValue.toFixed(2) : '—' }}
@@ -42,12 +49,13 @@ import { Summary }           from '../../models';
           </p>
         </div>
       </ng-container>
+
       <ng-template #noSummaryTpl>
-        <div class="text-gray-400 italic p-4 text-center">
+        <div class="relative z-10 text-gray-400 italic p-4 text-center">
           No hay un resumen disponible.
         </div>
       </ng-template>
-    </mat-card>
+    </div>
   `,
   styles: [`
     :host { display: block; height: 100%; }

--- a/tech-farming-frontend/src/app/predicciones/components/trend-card.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/components/trend-card.component.ts
@@ -2,7 +2,6 @@
 
 import { Component, Input } from '@angular/core';
 import { CommonModule }      from '@angular/common';
-import { MatCardModule }     from '@angular/material/card';
 
 import { TrendGaugeComponent } from './trend-gauge.component';
 
@@ -18,21 +17,22 @@ export interface Trend {
 @Component({
   selector: 'app-trend-card',
   standalone: true,
-  imports: [
-    CommonModule,
-    MatCardModule,
-    TrendGaugeComponent
-  ],
+  imports: [CommonModule, TrendGaugeComponent],
   template: `
-    <mat-card class="trend-card h-full bg-base-100 p-6 rounded-lg shadow-sm flex flex-col">
+    <div
+      class="trend-card card relative overflow-hidden h-full bg-base-100 p-6 rounded-xl shadow-sm flex flex-col hover:shadow-md hover:-translate-y-1 transition"
+    >
+      <div class="absolute inset-0 bg-gradient-to-br from-primary/5 to-secondary/5 pointer-events-none"></div>
+
       <!-- HEADER -->
-      <div class="flex items-center mb-4">
+      <div class="relative z-10 flex items-center mb-4">
         <app-trend-gauge [pct]="pct" [size]="48" class="mr-3"></app-trend-gauge>
+        <i [class]="trendIcon + ' text-2xl mr-2'"></i>
         <h2 class="text-xl font-semibold">Tendencia</h2>
       </div>
 
       <!-- CUERPO -->
-      <div class="flex-1">
+      <div class="relative z-10 flex-1">
         <!-- Título + porcentaje -->
         <p class="text-lg font-medium mb-2" [ngClass]="riskMsgClass">
           {{ trend?.title }} ({{ trend?.message }})
@@ -43,7 +43,7 @@ export interface Trend {
           {{ action }}
         </p>
       </div>
-    </mat-card>
+    </div>
   `,
   styles: [`
     :host { display: block; height: 100%; }
@@ -73,5 +73,17 @@ export class TrendCardComponent {
     if (p >= 10) return 'msg-error';
     if (p >= 5)  return 'msg-warning';
     return 'msg-success';
+  }
+
+  /** Icono según la tendencia */
+  get trendIcon(): string {
+    switch (this.trend?.type) {
+      case 'up':
+        return 'fas fa-arrow-up text-success';
+      case 'down':
+        return 'fas fa-arrow-down text-error';
+      default:
+        return 'fas fa-minus text-warning';
+    }
   }
 }


### PR DESCRIPTION
## Summary
- restyle SummaryCard with gradient background and icon
- restyle TrendCard similarly and show icon based on trend direction

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684b38d37eb8832a908e9b0eae12db60