### PR TITLE
Improve design for prediction cards

### DIFF
--- a/tech-farming-frontend/src/app/predicciones/components/summary-card.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/components/summary-card.component.ts
@@ -2,57 +2,51 @@
 
 import { Component, Input } from '@angular/core';
 import { CommonModule }      from '@angular/common';
-import { MatCardModule }     from '@angular/material/card';
 import { Summary }           from '../../models';
 
 @Component({
   selector: 'app-summary-card',
   standalone: true,
-  imports: [CommonModule, MatCardModule],
+  imports: [CommonModule],
   template: `
-    <mat-card class="summary-card h-full bg-base-100 p-6 rounded-lg shadow-sm flex flex-col">
-      <ng-container *ngIf="summary; else noSummaryTpl">
-        <h2 class="text-xl font-semibold mb-4">Resumen Predictivo</h2>
-        <div class="flex-1 space-y-2">
-          <p>
-            <strong>Última medida:</strong>
-            {{ summary.lastValue != null ? summary.lastValue.toFixed(2) : '—' }}
-          </p>
-          <p>
-            <strong>Predicción ({{ projectionLabel }}):</strong>
-            {{ summary.prediction != null ? summary.prediction.toFixed(2) : '—' }}
-          </p>
-          <p>
-            <strong>Rango histórico:</strong>
-            [
-              {{ summary.histMin != null ? summary.histMin.toFixed(1) : '—' }}
-              –
-              {{ summary.histMax != null ? summary.histMax.toFixed(1) : '—' }}
-            ]
-          </p>
-          <p>
-            <strong>Variación:</strong>
-            {{ summary.diff != null
-               ? (summary.diff >= 0 ? '+' : '') + summary.diff.toFixed(2)
-               : '—'
-            }}
-          </p>
-          <p *ngIf="summary.action" class="text-sm text-primary">
-            {{ summary.action }}
-          </p>
+    <ng-container *ngIf="summary; else noSummaryTpl">
+      <div class="stats bg-base-100 shadow-lg rounded-lg p-4">
+        <div class="stat">
+          <div class="stat-title text-lg font-medium">Última medida</div>
+          <div class="stat-value text-xl font-bold">
+            {{ summary.lastValue != null ? summary.lastValue.toFixed(2) : '—' }} °C
+          </div>
         </div>
-      </ng-container>
-      <ng-template #noSummaryTpl>
-        <div class="text-gray-400 italic p-4 text-center">
-          No hay un resumen disponible.
+        <div class="stat">
+          <div class="stat-title text-lg font-medium">Predicción ({{ projectionLabel }})</div>
+          <div class="stat-value text-xl font-bold">
+            {{ summary.prediction != null ? summary.prediction.toFixed(2) : '—' }} °C
+          </div>
         </div>
-      </ng-template>
-    </mat-card>
+        <div class="stat">
+          <div class="stat-title text-lg font-medium">Rango histórico</div>
+          <div class="stat-value">
+            [{{ summary.histMin != null ? summary.histMin.toFixed(1) : '—' }} – {{ summary.histMax != null ? summary.histMax.toFixed(1) : '—' }}]
+          </div>
+        </div>
+        <div class="stat">
+          <div class="stat-title text-lg font-medium">Variación</div>
+          <div class="stat-value text-xl font-bold" [ngClass]="{'text-error': summary.diff != null && summary.diff < 0}">
+            {{ summary.diff != null ? summary.diff.toFixed(2) : '—' }}
+          </div>
+          <div class="stat-desc text-sm" *ngIf="summary.action">{{ summary.action }}</div>
+        </div>
+      </div>
+    </ng-container>
+
+    <ng-template #noSummaryTpl>
+      <div class="text-gray-400 italic p-4 text-center">
+        No hay un resumen disponible.
+      </div>
+    </ng-template>
   `,
   styles: [`
     :host { display: block; height: 100%; }
-    .summary-card { border: 1px solid var(--p-base-200); }
-    .text-primary { color: var(--p-primary); }
   `]
 })
 export class SummaryCardComponent {

--- a/tech-farming-frontend/src/app/predicciones/components/trend-card.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/components/trend-card.component.ts
@@ -2,7 +2,6 @@
 
 import { Component, Input } from '@angular/core';
 import { CommonModule }      from '@angular/common';
-import { MatCardModule }     from '@angular/material/card';
 
 import { TrendGaugeComponent } from './trend-gauge.component';
 
@@ -18,38 +17,23 @@ export interface Trend {
 @Component({
   selector: 'app-trend-card',
   standalone: true,
-  imports: [
-    CommonModule,
-    MatCardModule,
-    TrendGaugeComponent
-  ],
+  imports: [CommonModule, TrendGaugeComponent],
   template: `
-    <mat-card class="trend-card h-full bg-base-100 p-6 rounded-lg shadow-sm flex flex-col">
-      <!-- HEADER -->
-      <div class="flex items-center mb-4">
-        <app-trend-gauge [pct]="pct" [size]="48" class="mr-3"></app-trend-gauge>
-        <h2 class="text-xl font-semibold">Tendencia</h2>
-      </div>
-
-      <!-- CUERPO -->
-      <div class="flex-1">
-        <!-- Título + porcentaje -->
-        <p class="text-lg font-medium mb-2" [ngClass]="riskMsgClass">
-          {{ trend?.title }} ({{ trend?.message }})
-        </p>
-
-        <!-- Mensaje específico de acción -->
-        <p *ngIf="action" class="text-sm font-medium mt-2">
-          {{ action }}
-        </p>
-      </div>
-    </mat-card>
+    <div
+      class="card w-48 bg-base-100 shadow-lg rounded-lg p-4 flex flex-col items-center gap-2 hover:shadow-xl hover:-translate-y-1 transition-transform transition-shadow focus:ring-2 focus:ring-primary"
+    >
+      <app-trend-gauge [pct]="pct" [size]="40"></app-trend-gauge>
+      <h4 class="text-lg font-medium">Tendencia</h4>
+      <p class="text-xl font-bold flex items-center gap-1" [ngClass]="riskMsgClass">
+        <i [class]="trendIcon"></i>
+        {{ pct | number:'1.0-1' }}%
+      </p>
+      <p *ngIf="action" class="text-sm text-gray-500/75 text-center">{{ action }}</p>
+    </div>
   `,
   styles: [`
-    :host { display: block; height: 100%; }
-    .trend-card { border: 1px solid var(--p-base-200); }
+    :host { display: block; }
 
-    /* Color del texto según nivel de riesgo */
     .msg-success { color: var(--p-success); }
     .msg-warning { color: var(--p-warning); }
     .msg-error   { color: var(--p-error); }
@@ -73,5 +57,17 @@ export class TrendCardComponent {
     if (p >= 10) return 'msg-error';
     if (p >= 5)  return 'msg-warning';
     return 'msg-success';
+  }
+
+  /** Icono según la tendencia */
+  get trendIcon(): string {
+    switch (this.trend?.type) {
+      case 'up':
+        return 'fas fa-arrow-up text-success';
+      case 'down':
+        return 'fas fa-arrow-down text-error';
+      default:
+        return 'fas fa-minus text-warning';
+    }
   }
 }

--- a/tech-farming-frontend/src/app/predicciones/predicciones.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/predicciones.component.ts
@@ -100,24 +100,29 @@ import { PrediccionesHeaderComponent } from './components/predicciones-header.co
             </div>
           </ng-container>
           <ng-template #dataTpl>
-            <!-- GRÁFICO -->
-            <div class="relative w-full h-96 bg-base-100 rounded-lg overflow-hidden shadow-xl animate-fade-in-down">
-              <app-prediction-chart
-                class="w-full h-full"
-                [historical]="data?.historical ?? []"
-                [future]    ="data?.future     ?? []"
-                [label]     ="selectedProjectionLabel"
-              ></app-prediction-chart>
-            </div>
+            <div class="space-y-4">
+              <!-- Chart -->
+              <div class="relative w-full h-96 bg-base-100 rounded-lg overflow-hidden shadow-xl p-6 animate-fade-in-down">
+                <app-prediction-chart
+                  class="w-full h-full"
+                  [historical]="data?.historical ?? []"
+                  [future]    ="data?.future     ?? []"
+                  [label]     ="selectedProjectionLabel"
+                ></app-prediction-chart>
+              </div>
 
-            <!-- RESUMEN & TENDENCIA -->
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 items-stretch">
-              <app-summary-card
-                class="h-full"
-                [summary]="data?.summary"
-                [projectionLabel]="selectedProjectionLabel"
-              ></app-summary-card>
-              <app-trend-card class="h-full" [trend]="uiTrend"></app-trend-card>
+              <!-- Resumen y Tendencia -->
+              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-12 gap-4">
+                <div class="col-span-12 sm:col-span-1 lg:col-span-6">
+                  <app-summary-card
+                    [summary]="data?.summary"
+                    [projectionLabel]="selectedProjectionLabel"
+                  ></app-summary-card>
+                </div>
+                <div class="col-span-12 sm:col-span-1 lg:col-span-6 flex sm:justify-center lg:justify-start">
+                  <app-trend-card [trend]="uiTrend"></app-trend-card>
+                </div>
+              </div>
             </div>
           </ng-template>
         </div>


### PR DESCRIPTION
## Summary
- restyle SummaryCard using daisyUI stats component
- restyle TrendCard as compact card with gauge and arrow
- arrange predictions view with cards under the chart

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684b38d37eb8832a908e9b0eae12db60