### PR TITLE
Use CSS vars for gauge colors

### DIFF
--- a/tech-farming-frontend/src/app/predicciones/components/trend-gauge.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/components/trend-gauge.component.ts
@@ -12,7 +12,7 @@ import { CommonModule } from '@angular/common';
       <!-- Arco de fondo -->
       <path
         d="M10,50 A40,40 0 0,1 90,50"
-        stroke="#ddd"
+        stroke="var(--color-base-300, #ddd)"
         stroke-width="10"
         fill="none"
       />
@@ -27,11 +27,11 @@ import { CommonModule } from '@angular/common';
       <line
         x1="50" y1="50"
         [attr.x2]="needleX" [attr.y2]="needleY"
-        stroke="#333"
+        stroke="var(--color-base-content, #333)"
         stroke-width="2"
       />
       <!-- Centro -->
-      <circle cx="50" cy="50" r="3" fill="#333"/>
+        <circle cx="50" cy="50" r="3" fill="var(--color-base-content, #333)"/>
     </svg>
   `,
   styles: [`


### PR DESCRIPTION
## Summary
- color theming for TrendGauge component

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_684b4632a9cc832a897ae9e9a53e6372