### PR TITLE
Fix trend card conditional visibility

### DIFF
--- a/tech-farming-frontend/src/app/predicciones/predicciones.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/predicciones.component.ts
@@ -119,7 +119,10 @@ import { PrediccionesHeaderComponent } from './components/predicciones-header.co
                     [projectionLabel]="selectedProjectionLabel"
                   ></app-summary-card>
                 </div>
-                <div class="col-span-12 sm:col-span-1 lg:col-span-6 flex sm:justify-center lg:justify-start">
+                <div
+                  class="col-span-12 sm:col-span-1 lg:col-span-6 flex sm:justify-center lg:justify-start"
+                  *ngIf="uiTrend"
+                >
                   <app-trend-card [trend]="uiTrend"></app-trend-card>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- only show trend card when uiTrend is defined

## Testing
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b46305364832a96f93f9cc7ada686