### PR TITLE
Adjust summary/trend columns on small screens

### DIFF
--- a/tech-farming-frontend/src/app/predicciones/predicciones.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/predicciones.component.ts
@@ -113,14 +113,14 @@ import { PrediccionesHeaderComponent } from './components/predicciones-header.co
 
               <!-- Resumen y Tendencia -->
               <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-12 gap-4">
-                <div class="col-span-12 sm:col-span-1 lg:col-span-6">
+                <div class="col-span-1 sm:col-span-1 lg:col-span-6">
                   <app-summary-card
                     [summary]="data?.summary"
                     [projectionLabel]="selectedProjectionLabel"
                   ></app-summary-card>
                 </div>
                 <div
-                  class="col-span-12 sm:col-span-1 lg:col-span-6 flex sm:justify-center lg:justify-start"
+                  class="col-span-1 sm:col-span-1 lg:col-span-6 flex sm:justify-center lg:justify-start"
                   *ngIf="uiTrend"
                 >
                   <app-trend-card [trend]="uiTrend"></app-trend-card>


### PR DESCRIPTION
## Summary
- fix summary/trend section grid classes to use col-span-1 on mobile

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4b9a2c24832aa0954997928bb0c1