### PR TITLE
Fix responsive filters for predictions

### DIFF
--- a/tech-farming-frontend/src/app/predicciones/predicciones.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/predicciones.component.ts
@@ -53,7 +53,7 @@ import { PrediccionesHeaderComponent } from './components/predicciones-header.co
           </div>
 
           <!-- FILTROS -->
-          <div class="grid gap-4" style="grid-template-columns: calc(100% * var(--inv-phi)) repeat(3, 1fr);">
+          <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
 
             <!-- Invernadero -->
             <app-filtro-select
@@ -135,8 +135,6 @@ import { PrediccionesHeaderComponent } from './components/predicciones-header.co
   styles: [`
     :host { display: block; position: relative; }
     :root {
-      --phi: 1.618;
-      --inv-phi: 0.618;
       --header-height: 3rem;
     }
   `]

--- a/tech-farming-frontend/src/styles.css
+++ b/tech-farming-frontend/src/styles.css
@@ -4,8 +4,6 @@
 @tailwind utilities;
 
 :root {
-    --phi: 1.618;
-    --inv-phi: 0.618;
     --header-height: 3rem; /* 48px aprox. coincidiendo con h-12 */
 }
 [data-theme='light'] {


### PR DESCRIPTION
## Summary
- make prediction filters responsive with Tailwind grid classes
- drop unused CSS variables

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684b50d0a4c0832abfa4d2c91a5657b3