### PR TITLE
Add zone predictions to dashboard

### DIFF
--- a/tech-farming-frontend/src/app/dashboard/components/zona-pred-card.component.ts
+++ b/tech-farming-frontend/src/app/dashboard/components/zona-pred-card.component.ts
@@ -1,0 +1,37 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Summary, Trend } from '../../models';
+import { SummaryCardComponent } from '../../predicciones/components/summary-card.component';
+import { TrendCardComponent, Trend as UITrend } from '../../predicciones/components/trend-card.component';
+
+@Component({
+  selector: 'app-zona-pred-card',
+  standalone: true,
+  imports: [CommonModule, SummaryCardComponent, TrendCardComponent],
+  template: `
+    <div class="card bg-base-100 border border-base-200 shadow-sm p-4 space-y-4">
+      <h3 class="text-lg font-semibold">{{ zonaNombre }}</h3>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <ng-container *ngFor="let p of preds">
+          <div class="space-y-2">
+            <h4 class="font-medium text-sm">{{ p.parametro }}</h4>
+            <app-summary-card [summary]="p.summary" [projectionLabel]="projectionLabel"></app-summary-card>
+            <app-trend-card [trend]="mapTrend(p.trend)"></app-trend-card>
+          </div>
+        </ng-container>
+      </div>
+    </div>
+  `,
+})
+export class ZonaPredCardComponent {
+  @Input() zonaNombre = '';
+  @Input() projectionLabel = '';
+  @Input() preds: Array<{ parametro: string; summary: Summary; trend: Trend }> = [];
+
+  mapTrend(api: Trend): UITrend {
+    let type: UITrend['type'] = 'stable';
+    if (api.icon === 'arrow-up') type = 'up';
+    if (api.icon === 'arrow-down') type = 'down';
+    return { title: api.text, message: api.comparison, type };
+  }
+}

--- a/tech-farming-frontend/src/app/dashboard/services/dashboard.service.ts
+++ b/tech-farming-frontend/src/app/dashboard/services/dashboard.service.ts
@@ -1,9 +1,9 @@
 // src/app/dashboard/services/dashboard.service.ts
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, map } from 'rxjs';
 
-import { Invernadero, Zona, Sensor } from '../../models';
+import { Invernadero, Zona, Sensor, PredicResult } from '../../models';
 import { BatchLectura, TimeSeriesService, HistorialResponse } from '../../sensores/time-series.service';
 import { AlertService, Alerta } from '../../alertas/alertas.service';
 
@@ -83,5 +83,22 @@ export class DashboardService {
 
   resolverAlerta(id: number) {
     return this.alertSvc.resolverAlerta(id);
+  }
+
+  /** GET /api/predict_influx */
+  getPredicciones(params: {
+    invernaderoId: number;
+    zonaId?: number;
+    horas: 6 | 12 | 24;
+    parametro: string;
+  }) {
+    const httpParams = new HttpParams()
+      .set('invernaderoId', params.invernaderoId)
+      .set('horas', params.horas)
+      .set('parametro', params.parametro)
+      .set('zonaId', params.zonaId != null ? params.zonaId : '');
+    return this.http.get<PredicResult>(`${this.apiUrl}/predict_influx`, {
+      params: httpParams
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add `/predict_influx` helper to dashboard service
- create `ZonaPredCardComponent` to display predictions per zone
- integrate prediction cards in dashboard with pagination and interval buttons

## Testing
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b6d8cbee0832a823ff5ddbebbf83e