### PR TITLE
Fix optional zonaId in getPredicciones

### DIFF
--- a/tech-farming-frontend/src/app/dashboard/services/dashboard.service.ts
+++ b/tech-farming-frontend/src/app/dashboard/services/dashboard.service.ts
@@ -92,11 +92,15 @@ export class DashboardService {
     horas: 6 | 12 | 24;
     parametro: string;
   }) {
-    const httpParams = new HttpParams()
-      .set('invernaderoId', params.invernaderoId)
-      .set('horas', params.horas)
-      .set('parametro', params.parametro)
-      .set('zonaId', params.zonaId != null ? params.zonaId : '');
+    let httpParams = new HttpParams()
+      .set('invernaderoId', params.invernaderoId.toString())
+      .set('horas', params.horas.toString())
+      .set('parametro', params.parametro);
+
+    if (params.zonaId != null) {
+      httpParams = httpParams.set('zonaId', params.zonaId.toString());
+    }
+
     return this.http.get<PredicResult>(`${this.apiUrl}/predict_influx`, {
       params: httpParams
     });


### PR DESCRIPTION
## Summary
- refine DashboardService.getPredicciones to only attach `zonaId` when defined

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: chromium snap not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b7384d044832a8cbd8a1979c7578b