### PR TITLE
Implementar resumen de predicciones por zona

### DIFF
--- a/tech-farming-frontend/src/app/dashboard/dashboard.component.ts
+++ b/tech-farming-frontend/src/app/dashboard/dashboard.component.ts
@@ -13,10 +13,19 @@ import { LineChartComponent } from './components/line-chart.component';
 import { AlertCardComponent } from './components/alert-card.component';
 import { TabsPanelComponent } from './components/tabs-panel.component';
 import { FooterComponent } from './components/footer.component';
+import { SummaryCardComponent } from '../predicciones/components/summary-card.component';
 import { DashboardService } from './services/dashboard.service';
 import { NotificationService } from '../shared/services/notification.service';
-import { Invernadero, Zona, Sensor, Alerta } from '../models';
-import { finalize } from 'rxjs';
+import { Invernadero, Zona, Sensor, Alerta, Summary } from '../models';
+import { finalize, forkJoin, map } from 'rxjs';
+
+interface ZoneSummary {
+  zone: Zona;
+  summaries: Array<{
+    param: string;
+    summary: Summary;
+  }>;
+}
 
 @Component({
   selector: 'app-dashboard-page',
@@ -29,6 +38,7 @@ import { finalize } from 'rxjs';
     AlertCardComponent,
     TabsPanelComponent,
     FooterComponent,
+    SummaryCardComponent,
   ],
   template: `
     <div *ngIf="!loading; else loadingTpl" class="flex flex-col h-full bg-base-200">
@@ -266,24 +276,24 @@ import { finalize } from 'rxjs';
 
             <!-- Tab “Predicciones” -->
             <ng-container *ngIf="tabActiva === 'predicciones'">
-              <ng-container *ngIf="predicciones.length; else sinPredicciones">
-                <div class="space-y-3 pb-4">
-                  <div
-                    *ngFor="let p of predicciones"
-                    class="bg-base-100 border border-base-200 rounded-lg p-3 shadow-sm hover:shadow-md transition-shadow duration-200"
-                  >
-                    <p class="font-semibold text-base-content">
-                      Predicción a {{ p.intervalo }}h: {{ p.valor }} {{ getUnidad(p.variable) }}
-                    </p>
-                    <p class="text-sm text-base-content/60">Confianza: {{ p.confianza }}%</p>
-                    <p class="text-sm text-base-content/60">Recomendación: {{ p.recomendacion }}</p>
+              <ng-container *ngIf="zoneSummaries.length; else sinPredicciones">
+                <div class="space-y-6">
+                  <div *ngFor="let zs of zoneSummaries" class="bg-base-100 border rounded-lg p-4">
+                    <h3 class="text-lg font-semibold mb-2">{{ zs.zone.nombre }}</h3>
+                    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+                      <app-summary-card
+                        *ngFor="let s of zs.summaries"
+                        [summary]="s.summary"
+                        [projectionLabel]="intervaloSeleccionado + 'h'"
+                      ></app-summary-card>
+                    </div>
                   </div>
                 </div>
               </ng-container>
               <ng-template #sinPredicciones>
                 <div class="text-center text-base-content/60 py-8">
                   <i class="ri-calendar-event-line text-3xl text-info mb-2" aria-hidden="true"></i>
-                  <p>Selecciona intervalo para ver predicciones.</p>
+                  <p>No hay predicciones para la zona seleccionada.</p>
                 </div>
               </ng-template>
             </ng-container>
@@ -464,14 +474,8 @@ export class DashboardPageComponent implements OnInit, AfterViewInit {
   }> = [];
   resolviendoId: number | null = null;
 
-  // ───────── PREDICCIONES SIMULADAS ─────────
-  predicciones: {
-    intervalo: 6 | 12 | 24;
-    valor: number;
-    confianza: number;
-    recomendacion: string;
-    variable: 'Temperatura' | 'Humedad' | 'Nitrógeno';
-  }[] = [];
+  // ───────── PREDICCIONES POR ZONA ─────────
+  zoneSummaries: ZoneSummary[] = [];
 
   // ───────── TAB ACTIVA ─────────
   tabActiva: 'alertas' | 'predicciones' | 'acciones' = 'alertas';
@@ -503,6 +507,7 @@ export class DashboardPageComponent implements OnInit, AfterViewInit {
   onZonaChange(): void {
     this.cargarAlertas();
     this.cambiarIntervalo(this.intervaloSeleccionado);
+    this.loadZoneSummaries();
   }
 
   aplicarFiltros(): void {
@@ -569,6 +574,7 @@ export class DashboardPageComponent implements OnInit, AfterViewInit {
           this.tooltipFijo = `${ultimoVal ?? '-'} ${unidad}`;
           this.ultimaActualizacion = new Date();
           this.updateFormattedLastUpdate();
+          this.loadZoneSummaries();
         },
         error: () => this.notify.error('Error al cargar historial')
       });
@@ -712,6 +718,47 @@ export class DashboardPageComponent implements OnInit, AfterViewInit {
         }
       },
       error: () => this.notify.error('Error al cargar sensores')
+    });
+  }
+
+  private loadZoneSummaries() {
+    if (!this.filtros.invernaderoId) return;
+    this.loading = true;
+
+    const allZones = this.zonasMap[this.filtros.invernaderoId!] || [];
+    const targetZones = this.filtros.zonaId
+      ? allZones.filter(z => z.id === this.filtros.zonaId)
+      : allZones;
+
+    const calls = targetZones.map(zone => {
+      const paramCalls = this.variablesDisponibles.map(v =>
+        this.dashSvc.getPredicciones({
+          invernaderoId: this.filtros.invernaderoId!,
+          zonaId: zone.id,
+          parametro: v.nombre,
+          horas: this.intervaloSeleccionado
+        }).pipe(
+          map(res => ({
+            param: v.nombre,
+            summary: {
+              lastValue: res.historical.slice(-1)[0]?.value,
+              prediction: res.future.slice(-1)[0]?.value,
+              diff: (res.future.slice(-1)[0]?.value ?? 0) - (res.historical.slice(-1)[0]?.value ?? 0),
+              action: res.summary.action,
+            } as Summary
+          }))
+        )
+      );
+
+      return forkJoin(paramCalls).pipe(
+        map(summaries => ({ zone, summaries }))
+      );
+    });
+
+    forkJoin(calls).pipe(
+      finalize(() => this.loading = false)
+    ).subscribe(results => {
+      this.zoneSummaries = results;
     });
   }
 

--- a/tech-farming-frontend/src/app/dashboard/services/dashboard.service.ts
+++ b/tech-farming-frontend/src/app/dashboard/services/dashboard.service.ts
@@ -3,7 +3,8 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, map } from 'rxjs';
 
-import { Invernadero, Zona, Sensor } from '../../models';
+import { Invernadero, Zona, Sensor, PredicParams, PredicResult } from '../../models';
+import { PrediccionesService } from '../../predicciones/predicciones.service';
 import { BatchLectura, TimeSeriesService, HistorialResponse } from '../../sensores/time-series.service';
 import { AlertService, Alerta } from '../../alertas/alertas.service';
 
@@ -14,7 +15,8 @@ export class DashboardService {
   constructor(
     private http: HttpClient,
     private tsSvc: TimeSeriesService,
-    private alertSvc: AlertService
+    private alertSvc: AlertService,
+    private predSvc: PrediccionesService
   ) {}
 
   /** GET /api/invernaderos/getInvernaderos */
@@ -44,6 +46,10 @@ export class DashboardService {
   getLecturas(ids: number[]): Observable<BatchLectura[]> {
     const q = ids.join(',');
     return this.http.get<BatchLectura[]>(`${this.apiUrl}/sensores/lecturas?ids=${q}`);
+  }
+
+  getPredicciones(params: PredicParams): Observable<PredicResult> {
+    return this.predSvc.getPredicciones(params);
   }
 
   /** Delegates to TimeSeriesService.getHistorial */


### PR DESCRIPTION
## Summary
- exponer `getPredicciones` en `DashboardService`
- construir `zoneSummaries` en `DashboardPageComponent`
- actualizar la pestaña de Predicciones para mostrar tarjetas de resumen

## Testing
- `npm test --prefix tech-farming-frontend` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684b8c81c8c4832ab7adca71e24858e6