### PR TITLE
Handle invite errors

### DIFF
--- a/tech-farming-backend/app/routes/usuarios.py
+++ b/tech-farming-backend/app/routes/usuarios.py
@@ -63,9 +63,12 @@ def invitar_usuario():
     redirect_url = f"http://localhost:4200/set-password?invitacion=true"
 
     # Invitar usuario con Supabase Admin API
-    response = supabase.auth.admin.invite_user_by_email(email, {
-        "redirect_to": redirect_url
-    })
+    try:
+        response = supabase.auth.admin.invite_user_by_email(email, {
+            "redirect_to": redirect_url
+        })
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
 
     if response.user is None:
         return jsonify({"error": "Error al invitar usuario con Supabase"}), 400


### PR DESCRIPTION
## Summary
- handle Supabase invite errors in `usuarios.invitar_usuario`

## Testing
- `python -m py_compile tech-farming-backend/app/routes/usuarios.py`
- `curl -s -X POST http://127.0.0.1:5000/api/usuarios/trabajadores -H "Content-Type: application/json" -d '{"email":"invalid","nombre":"Test","apellido":"User","telefono":"123","permisos":{"editar":true}}'`


------
https://chatgpt.com/codex/tasks/task_e_684b8e6bf8ec832a8f0689a219115e58