### PR TITLE
Display error in admin modal

### DIFF
--- a/tech-farming-frontend/src/app/admin/components/admin-create-modal.component.ts
+++ b/tech-farming-frontend/src/app/admin/components/admin-create-modal.component.ts
@@ -71,6 +71,8 @@ import { SupabaseService } from '../../services/supabase.service';
           </div>
         </div>
 
+        <div *ngIf="error" class="text-error">{{ error }}</div>
+
         <!-- BOTONES -->
         <div class="modal-action mt-6 flex justify-end gap-2">
           <button type="button" (click)="close.emit()" class="btn btn-outline">Cancelar</button>
@@ -123,6 +125,7 @@ export class AdminCreateModalComponent {
       });
 
       if (response.success) {
+        this.error = '';
         this.mensajeConfirmacion = 'Usuario creado correctamente.';
         this.confirmacionVisible = true;
         setTimeout(() => {


### PR DESCRIPTION
## Summary
- show error messages in AdminCreateModalComponent template
- clear error message when a worker is created successfully

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684b8e6b3f24832abfc9c430b0a5e497