### PR TITLE
Add user deletion feature with confirmation

### DIFF
--- a/tech-farming-backend/app/routes/usuarios.py
+++ b/tech-farming-backend/app/routes/usuarios.py
@@ -130,3 +130,14 @@ def actualizar_permisos(usuario_id):
 
     db.session.commit()
     return jsonify({"mensaje": "Permisos actualizados correctamente"}), 200
+
+@router.route('/trabajadores/<int:usuario_id>', methods=['DELETE'])
+def eliminar_trabajador(usuario_id):
+    usuario = Usuario.query.get_or_404(usuario_id, description="Usuario no encontrado")
+    try:
+        db.session.delete(usuario)
+        db.session.commit()
+        return '', 204
+    except Exception:
+        db.session.rollback()
+        return jsonify({"error": "No se pudo eliminar el usuario"}), 500

--- a/tech-farming-frontend/src/app/admin/admin.component.ts
+++ b/tech-farming-frontend/src/app/admin/admin.component.ts
@@ -9,6 +9,7 @@ import { AdminCreateModalComponent } from './components/admin-create-modal.compo
 import { AdminEditModalComponent } from './components/admin-edit-modal.component';
 import { AdminModalWrapperComponent } from './components/admin-modal-wrapper.component';
 import { AdminCardListComponent } from './components/admin-card-list.component';
+import { AdminDeleteModalComponent } from './components/admin-delete-modal.component';
 
 interface Usuario {
   id: number;
@@ -32,7 +33,8 @@ interface Usuario {
     AdminCardListComponent,
     AdminCreateModalComponent,
     AdminEditModalComponent,
-    AdminModalWrapperComponent],
+    AdminModalWrapperComponent,
+    AdminDeleteModalComponent],
   template: `
     <div *ngIf="!loading; else loadingTpl">
     <app-admin-header (create)="abrirModal()"></app-admin-header>
@@ -45,7 +47,8 @@ interface Usuario {
         [loading]="!isDataFullyLoaded"
         [rowCount]="pageSize"
         (paginaCambiada)="cambiarPagina($event)"
-        (editarUsuario)="editar($event)">
+        (editarUsuario)="editar($event)"
+        (eliminarUsuario)="confirmarEliminar($event)">
       </app-admin-table>
     </div>
 
@@ -54,7 +57,8 @@ interface Usuario {
       [usuarios]="usuariosFiltrados"
       [loading]="!isDataFullyLoaded"
       [rowCount]="pageSize"
-      (editarUsuario)="editar($event)">
+      (editarUsuario)="editar($event)"
+      (eliminarUsuario)="confirmarEliminar($event)">
     </app-admin-card-list>
 
     <app-admin-modal-wrapper *ngIf="modal.modalType$ | async as type">
@@ -75,6 +79,18 @@ interface Usuario {
                 (saved)="onUsuarioEditado()"
                 (close)="modal.closeWithAnimation()">
             </app-admin-edit-modal>
+          </ng-container>
+        </ng-container>
+
+        <!-- ELIMINAR USUARIO -->
+        <ng-container *ngSwitchCase="'delete'">
+          <ng-container *ngIf="selectedUsuario">
+            <app-admin-delete-modal
+              [usuarioId]="selectedUsuario.id"
+              [nombre]="selectedUsuario.nombre"
+              (deleted)="onUsuarioEliminado()"
+              (cancel)="modal.closeWithAnimation()">
+            </app-admin-delete-modal>
           </ng-container>
         </ng-container>
       <!-- Otros tipos de modales (edit, delete) se agregarían aquí -->
@@ -167,6 +183,16 @@ export class AdminComponent implements OnInit {
       }
     };
     this.modal.openModal('edit');
+  }
+
+  confirmarEliminar(usuario: Usuario) {
+    this.selectedUsuario = { id: usuario.id, nombre: usuario.nombre } as any;
+    this.modal.openModal('delete');
+  }
+
+  onUsuarioEliminado() {
+    this.modal.closeWithAnimation();
+    this.cargarUsuarios();
   }
 
   private startLoading(): void {

--- a/tech-farming-frontend/src/app/admin/admin.service.ts
+++ b/tech-farming-frontend/src/app/admin/admin.service.ts
@@ -69,4 +69,11 @@ export class AdminService {
       eliminar: permisos.eliminar
     });
   }
+
+  /**
+   * Elimina un trabajador por ID
+   */
+  eliminarTrabajador(usuarioId: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/trabajadores/${usuarioId}`);
+  }
 }

--- a/tech-farming-frontend/src/app/admin/components/admin-card-list.component.ts
+++ b/tech-farming-frontend/src/app/admin/components/admin-card-list.component.ts
@@ -28,8 +28,9 @@ interface Usuario {
             <span>Crear: {{ u.puedeCrear ? '✔️' : '❌' }}</span>
             <span>Eliminar: {{ u.puedeEliminar ? '✔️' : '❌' }}</span>
           </div>
-          <div class="text-right">
+          <div class="text-right space-x-2">
             <button class="btn btn-outline btn-sm" (click)="editarUsuario.emit(u)">Editar</button>
+            <button class="btn btn-error btn-sm" (click)="eliminarUsuario.emit(u)">Eliminar</button>
           </div>
         </div>
       </ng-container>
@@ -48,6 +49,7 @@ export class AdminCardListComponent {
   @Input() loading = false;
   @Input() rowCount = 5;
   @Output() editarUsuario = new EventEmitter<Usuario>();
+  @Output() eliminarUsuario = new EventEmitter<Usuario>();
 
   get skeletonArray() {
     return Array.from({ length: this.rowCount });

--- a/tech-farming-frontend/src/app/admin/components/admin-delete-modal.component.ts
+++ b/tech-farming-frontend/src/app/admin/components/admin-delete-modal.component.ts
@@ -1,0 +1,54 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { AdminService } from '../admin.service';
+
+@Component({
+  selector: 'app-admin-delete-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="p-6 bg-base-100 rounded-lg shadow-lg max-w-md w-full space-y-4">
+      <h2 class="text-xl font-bold text-error">⚠️ Eliminar usuario</h2>
+      <p>¿Estás seguro de que quieres eliminar a <strong>{{ nombre }}</strong>?</p>
+      <p>Escribe <strong>Eliminar {{ nombre }}</strong> para confirmar:</p>
+      <input
+        type="text"
+        class="input input-bordered w-full"
+        [(ngModel)]="confirmText"
+        placeholder="Escribe aquí para confirmar"
+      />
+      <div class="flex justify-end space-x-2 pt-2">
+        <button class="btn btn-ghost" (click)="cancel.emit()" [disabled]="loading">Cancelar</button>
+        <button class="btn btn-error" [disabled]="!canDelete || loading" (click)="onDelete()">Eliminar</button>
+      </div>
+    </div>
+  `
+})
+export class AdminDeleteModalComponent {
+  @Input() usuarioId!: number;
+  @Input() nombre = '';
+  @Output() deleted = new EventEmitter<number>();
+  @Output() cancel = new EventEmitter<void>();
+
+  confirmText = '';
+  loading = false;
+
+  constructor(private svc: AdminService) {}
+
+  get canDelete(): boolean {
+    return this.confirmText.trim() === `Eliminar ${this.nombre}`;
+  }
+
+  onDelete() {
+    if (this.loading) return;
+    this.loading = true;
+    this.svc.eliminarTrabajador(this.usuarioId).subscribe({
+      next: () => this.deleted.emit(this.usuarioId),
+      error: () => {
+        this.loading = false;
+        alert('No se pudo eliminar el usuario.');
+      }
+    });
+  }
+}

--- a/tech-farming-frontend/src/app/admin/components/admin-table.component.ts
+++ b/tech-farming-frontend/src/app/admin/components/admin-table.component.ts
@@ -40,8 +40,9 @@ interface Usuario {
             <td>{{ u.puedeEditar ? '✔️' : '❌' }}</td>
             <td>{{ u.puedeCrear ? '✔️' : '❌' }}</td>
             <td>{{ u.puedeEliminar ? '✔️' : '❌' }}</td>
-            <td class="text-center">
+            <td class="text-center space-x-2">
               <button class="btn btn-sm btn-outline" (click)="editarUsuario.emit(u)">Editar</button>
+              <button class="btn btn-sm btn-error" (click)="eliminarUsuario.emit(u)">Eliminar</button>
             </td>
           </tr>
         </tbody>
@@ -98,6 +99,7 @@ export class AdminTableComponent {
   @Input() rowCount = 5;
   @Output() paginaCambiada = new EventEmitter<number>();
   @Output() editarUsuario = new EventEmitter<Usuario>();
+  @Output() eliminarUsuario = new EventEmitter<Usuario>();
 
   irPagina(p: number) {
     if (p < 1 || p > this.totalPaginas) return;


### PR DESCRIPTION
## Summary
- allow deleting workers from backend
- add frontend service call to delete workers
- create deletion confirmation modal
- wire up delete buttons in admin UI

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684b916f1c54832ab082595d2f0f90d1