### PR TITLE
Update predictions layout

### DIFF
--- a/tech-farming-frontend/src/app/dashboard/dashboard.component.ts
+++ b/tech-farming-frontend/src/app/dashboard/dashboard.component.ts
@@ -299,7 +299,10 @@ interface ZoneSummary {
                 <div class="space-y-6">
                   <div *ngFor="let zs of zoneSummaries" class="bg-base-100 border rounded-lg p-4">
                     <h3 class="text-lg font-semibold mb-2">{{ zs.zone.nombre }}</h3>
-                    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                    <div
+                      class="grid gap-4"
+                      style="grid-template-columns: repeat(auto-fit,minmax(12rem,1fr));"
+                    >
                       <app-summary-card
                         *ngFor="let s of zs.summaries"
                         [summary]="s.summary"

--- a/tech-farming-frontend/src/app/predicciones/components/summary-card.component.ts
+++ b/tech-farming-frontend/src/app/predicciones/components/summary-card.component.ts
@@ -20,21 +20,21 @@ import { Summary }           from '../../models';
           <!-- Última medida -->
           <div class="flex flex-col">
             <span class="text-lg font-medium">Última medida</span>
-            <span class="text-2xl font-bold whitespace-nowrap">
+            <span class="text-xl md:text-2xl font-bold">
               {{ summary.lastValue != null ? (summary.lastValue | number:'1.2-2') : '—' }} {{ unit }}
             </span>
           </div>
           <!-- Predicción -->
           <div class="flex flex-col">
             <span class="text-lg font-medium">Predicción ({{ projectionLabel }})</span>
-            <span class="text-2xl font-bold whitespace-nowrap">
+            <span class="text-xl md:text-2xl font-bold">
               {{ summary.prediction != null ? (summary.prediction | number:'1.2-2') : '—' }} {{ unit }}
             </span>
           </div>
           <!-- Rango histórico -->
           <div class="flex flex-col">
             <span class="text-lg font-medium">Rango histórico</span>
-            <span class="text-2xl font-bold whitespace-nowrap">
+            <span class="text-xl md:text-2xl font-bold">
               [{{ summary.histMin != null ? (summary.histMin | number:'1.1-1') : '—' }}
                – {{ summary.histMax != null ? (summary.histMax | number:'1.1-1') : '—' }}]
             </span>
@@ -43,7 +43,7 @@ import { Summary }           from '../../models';
           <div class="flex flex-col">
             <span class="text-lg font-medium">Variación</span>
             <span
-              class="text-2xl font-bold whitespace-nowrap"
+              class="text-xl md:text-2xl font-bold"
               [ngClass]="{
                 'text-success': summary.diff != null && summary.diff > 0,
                 'text-error':   summary.diff != null && summary.diff < 0


### PR DESCRIPTION
## Summary
- fix grid on dashboard predictions tab to wrap summary cards
- tweak summary card font sizes and wrap behavior

## Testing
- `npx tsc -p tech-farming-frontend/tsconfig.app.json`


------
https://chatgpt.com/codex/tasks/task_e_684ba070885c832a9f6a4e7066a3860d