### PR TITLE
Limit chart decimals

### DIFF
--- a/tech-farming-frontend/src/app/dashboard/components/line-chart.component.ts
+++ b/tech-farming-frontend/src/app/dashboard/components/line-chart.component.ts
@@ -140,7 +140,8 @@ export class LineChartComponent implements OnInit, AfterViewInit, OnDestroy {
             ticks: {
               color: baseTextColor,
               stepSize: 5,
-              font: { family: 'Inter, sans-serif', size: 12, weight: 500 }
+              font: { family: 'Inter, sans-serif', size: 12, weight: 500 },
+              callback: (value: string | number) => Number(value).toFixed(2)
             },
           },
         },
@@ -161,7 +162,7 @@ export class LineChartComponent implements OnInit, AfterViewInit, OnDestroy {
               label: (ctx: TooltipItem<'line'>) => {
                 const rawValue = ctx.parsed.y;
                 const unidad = this.getUnidad(this.variable);
-                return `${this.variable}: ${rawValue} ${unidad}`;
+                return `${this.variable}: ${Number(rawValue).toFixed(2)} ${unidad}`;
               },
             },
           },


### PR DESCRIPTION
## Summary
- format tooltip labels with 2 decimal precision in dashboard line chart
- show Y axis tick values with two decimal places

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684bab32f770832a9881f460a413bb5b