### PR TITLE
Increase sensor name search length

### DIFF
--- a/tech-farming-frontend/src/app/sensores/components/sensor-filters.component.ts
+++ b/tech-farming-frontend/src/app/sensores/components/sensor-filters.component.ts
@@ -122,7 +122,7 @@ import { ZonaService }       from '../../invernaderos/zona.service';
                 type="text"
                 formControlName="search"
                 placeholder="Nombre del sensor..."
-                maxlength="15"
+                maxlength="30"
                 class="input input-bordered pl-10 w-full text-sm min-w-0"
               />
             </div>
@@ -130,7 +130,7 @@ import { ZonaService }       from '../../invernaderos/zona.service';
               *ngIf="searchControl.invalid && searchControl.hasError('maxlength')"
               class="text-xs text-error mt-1"
             >
-              Máximo 15 caracteres.
+              Máximo 30 caracteres.
             </p>
           </div>
 
@@ -210,7 +210,7 @@ export class SensorFiltersComponent implements OnInit, OnDestroy {
       tipoSensor:  [''],
       estado:      [''],
       sortBy:      [''],
-      search:       ['', [Validators.maxLength(15)]],  // límite 15 chars
+      search:       ['', [Validators.maxLength(30)]],  // límite 30 chars
     });
 
     this.invSub = this.filterForm.get('invernadero')!


### PR DESCRIPTION
## Summary
- allow longer sensor search name input

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `python3 app/test_pg.py` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_684bad36b114832a82aa7ea2be6406b2