### PR TITLE
Fix duplicated zone change and remove redundant call

### DIFF
--- a/tech-farming-frontend/src/app/dashboard/dashboard.component.ts
+++ b/tech-farming-frontend/src/app/dashboard/dashboard.component.ts
@@ -81,7 +81,6 @@ interface ZoneSummary {
                 [disabled]="!filtros.invernaderoId"
                 [ngClass]="{ 'opacity-50 cursor-not-allowed': !filtros.invernaderoId }"
                 aria-label="Selecciona Zona"
-                (change)="onZonaChange()"
               >
                 <option [ngValue]="null">— Zona —</option>
                 <option *ngFor="let z of zonasMap[filtros.invernaderoId!]" [ngValue]="z.id">
@@ -509,7 +508,6 @@ export class DashboardPageComponent implements OnInit, AfterViewInit {
   onZonaChange(): void {
     this.cargarAlertas();
     this.cambiarIntervalo(this.intervaloSeleccionado);
-    this.loadZoneSummaries();
   }
 
   aplicarFiltros(): void {


### PR DESCRIPTION
## Summary
- remove duplicate change handler on zone `<select>`
- avoid redundant `loadZoneSummaries()` in `onZonaChange`

## Testing
- `npm test` *(fails: No binary for Chrome)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684baf426d30832aa2a61bfd1ed66331