### PR TITLE
Add alert severity colors to greenhouse table badges

### DIFF
--- a/tech-farming-backend/app/routes/invernaderos.py
+++ b/tech-farming-backend/app/routes/invernaderos.py
@@ -40,14 +40,23 @@ def listar_invernaderos():
                 SensorParametro.sensor_id.in_(sensor_ids)
             )
 
-            # 5) Contar cuántas alertas ACTIVAS (tanto de tipo “Error” como “Umbral”)
-            alertas_activas = db.session.query(func.count(Alerta.id)).filter(
+            # 5) Obtener niveles de las alertas activas asociadas a este invernadero
+            alertas = db.session.query(Alerta.nivel).filter(
                 Alerta.estado == 'Activa',
                 or_(
                     Alerta.sensor_parametro_id.in_(param_ids),
                     Alerta.sensor_id.in_(sensor_ids)
                 )
-            ).scalar()
+            ).all()
+            alertas_activas = len(alertas)
+
+            niveles = [a.nivel for a in alertas]
+            if 'Crítico' in niveles:
+                nivel_alerta = 'Crítico'
+            elif 'Advertencia' in niveles:
+                nivel_alerta = 'Advertencia'
+            else:
+                nivel_alerta = None
 
             # 6) Formatear el texto de “estado”
             if alertas_activas == 0:
@@ -66,6 +75,7 @@ def listar_invernaderos():
                 "zonasActivas":   len(zonas_activas),
                 "sensoresActivos": len(sensores_activos),
                 "estado":         estado,
+                "nivel":          nivel_alerta,
                 "zonas": [
                     {
                         "id":         z.id,
@@ -134,13 +144,22 @@ def estados_alerta():
             # ).count()
 
             # AHORA:
-            alertas_activas = db.session.query(func.count(Alerta.id)).filter(
+            alertas = db.session.query(Alerta.nivel).filter(
                 Alerta.estado == 'Activa',
                 or_(
                     Alerta.sensor_parametro_id.in_(param_ids),
                     Alerta.sensor_id.in_(sensor_ids)
                 )
-            ).scalar()
+            ).all()
+            alertas_activas = len(alertas)
+
+            niveles = [a.nivel for a in alertas]
+            if 'Crítico' in niveles:
+                nivel_alerta = 'Crítico'
+            elif 'Advertencia' in niveles:
+                nivel_alerta = 'Advertencia'
+            else:
+                nivel_alerta = None
 
             if alertas_activas == 0:
                 estado = "Sin alertas"
@@ -151,7 +170,8 @@ def estados_alerta():
 
             result.append({
                 "id": inv.id,
-                "estado": estado
+                "estado": estado,
+                "nivel": nivel_alerta
             })
 
         return jsonify(result), 200

--- a/tech-farming-frontend/src/app/invernaderos/components/invernadero-card-list.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/invernadero-card-list.component.ts
@@ -18,10 +18,9 @@ import { Invernadero } from '../models/invernadero.model';
             <span
               class="badge badge-sm"
               [ngClass]="{
-                'badge-success': inv.estado === 'Activo',
-                'badge-warning': inv.estado === 'Inactivo',
-                'badge-error':   inv.estado === 'Mantenimiento',
-                'badge-neutral': inv.estado === 'Sin sensores'
+                'badge-error': inv.nivel === 'Crítico',
+                'badge-warning': inv.nivel === 'Advertencia',
+                'badge-success': !inv.nivel
               }"
             >{{ inv.estado }}</span>
           </div>

--- a/tech-farming-frontend/src/app/invernaderos/components/invernadero-table.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/invernadero-table.component.ts
@@ -28,10 +28,9 @@ import { Invernadero } from '../models/invernadero.model';
               <span
                 class="badge badge-md"
                 [ngClass]="{
-                  'badge-success': inv.estado === 'Activo',
-                  'badge-warning': inv.estado === 'Inactivo',
-                  'badge-error':   inv.estado === 'Mantenimiento',
-                  'badge-outline': inv.estado === 'Sin sensores'
+                  'badge-error': inv.nivel === 'Crítico',
+                  'badge-warning': inv.nivel === 'Advertencia',
+                  'badge-success': !inv.nivel
                 }"
               >
                 {{ inv.estado }}

--- a/tech-farming-frontend/src/app/invernaderos/invernaderos.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/invernaderos.component.ts
@@ -274,7 +274,10 @@ export class InvernaderosComponent implements OnInit, OnDestroy {
           // Solo actualizamos el “estado” en cada invernadero visible
           estados.forEach((est: any) => {
             const inv = this.invernaderos.find(i => i.id === est.id);
-            if (inv) inv.estado = est.estado || 'Sin alertas';
+            if (inv) {
+              inv.estado = est.estado || 'Sin alertas';
+              inv.nivel = est.nivel ?? null;
+            }
           });
         }
       }),

--- a/tech-farming-frontend/src/app/invernaderos/invernaderos.service.ts
+++ b/tech-farming-frontend/src/app/invernaderos/invernaderos.service.ts
@@ -89,11 +89,11 @@ export class InvernaderoService {
   getEstadosAlerta(
     page: number,
     pageSize: number
-  ): Observable<Array<{ id: number; estado: string }>> {
+  ): Observable<Array<{ id: number; estado: string; nivel: 'Advertencia' | 'Crítico' | null }>> {
     const params = new HttpParams()
       .set('page', page)
       .set('pageSize', pageSize);
-    return this.http.get<Array<{ id: number; estado: string }>>(
+    return this.http.get<Array<{ id: number; estado: string; nivel: 'Advertencia' | 'Crítico' | null }>>(
       `${this.baseUrl}/estados-alerta`,
       { params }
     );

--- a/tech-farming-frontend/src/app/invernaderos/models/invernadero.model.ts
+++ b/tech-farming-frontend/src/app/invernaderos/models/invernadero.model.ts
@@ -20,4 +20,5 @@ export interface Invernadero {
   sensoresActivos?: number;
   sensoresTotales?: number;
   estado?: string;  // ej: "2 alertas activas" o "Sin alertas"
+  nivel?: 'Advertencia' | 'Crítico' | null;
 }


### PR DESCRIPTION
## Summary
- backend `/api/invernaderos` and `/api/invernaderos/estados-alerta` now return alert severity via `nivel`
- badge coloring in greenhouse table and card list uses `nivel`
- frontend models and service updated for new field
- refresh logic updates `nivel` when polling

## Testing
- `npm test` *(fails: No binary for Chrome)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684bb0941134832a9f1b71b5b4c1bdc6