### PR TITLE
Fix red alert border

### DIFF
--- a/tech-farming-frontend/src/styles.css
+++ b/tech-farming-frontend/src/styles.css
@@ -83,3 +83,6 @@
   .pulse-alerta {
     animation: pulse-alerta 1.5s ease-in-out infinite;
   }
+/* Ensure red alerts have visible border */
+.alert-error { border: var(--border) solid var(--color-error); }
+


### PR DESCRIPTION
## Summary
- add a CSS rule so error alerts have a visible border

## Testing
- `npm test --silent -- --browsers=ChromeHeadless --watch=false` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_684bb17459ac832ab69b50458aeed0f0