### PR TITLE
Add sensors count info to zones

### DIFF
--- a/tech-farming-backend/app/routes/zonas.py
+++ b/tech-farming-backend/app/routes/zonas.py
@@ -11,14 +11,22 @@ router = Blueprint('zonas', __name__, url_prefix='/api')
 @router.route('/invernaderos/<int:inv_id>/zonas', methods=['GET'])
 def listar_zonas_por_invernadero(inv_id):
     inv = InvernaderoModel.query.get_or_404(inv_id, description="Invernadero no encontrado")
-    zonas = ZonaModel.query.filter_by(invernadero_id=inv_id).all()
-    return jsonify([{
-        "id":       z.id,
-        "nombre":   z.nombre,
-        "descripcion": z.descripcion,
-        "activo":   z.activo,
-        "creado_en": z.creado_en.isoformat() if z.creado_en else None
-    } for z in zonas]), 200
+    zonas = (
+        ZonaModel.query
+        .options(db.joinedload(ZonaModel.sensores))
+        .filter_by(invernadero_id=inv_id)
+        .all()
+    )
+    return jsonify([
+        {
+            "id":       z.id,
+            "nombre":   z.nombre,
+            "descripcion": z.descripcion,
+            "activo":   z.activo,
+            "creado_en": z.creado_en.isoformat() if z.creado_en else None,
+            "sensores_count": len(z.sensores)
+        } for z in zonas
+    ]), 200
 
 @router.route('/zonas', methods=['POST'])
 @usuario_autenticado_requerido

--- a/tech-farming-frontend/src/app/invernaderos/components/delete-invernadero-with-summary.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/delete-invernadero-with-summary.component.ts
@@ -146,7 +146,7 @@ export class DeleteInvernaderoWithSummaryComponent implements OnInit {
         this.zonas = detalle.zonas.map((z: Zona) => ({
           nombre: z.nombre,
           activo: z.activo,
-          sensoresCount: Array.isArray((z as any).sensores) ? (z as any).sensores.length : 0
+          sensoresCount: (z as any).sensores_count ?? (Array.isArray((z as any).sensores) ? (z as any).sensores.length : 0)
         }));
 
         this.isLoading = false;

--- a/tech-farming-frontend/src/app/invernaderos/components/invernadero-edit-inline-zonas.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/invernadero-edit-inline-zonas.component.ts
@@ -400,7 +400,9 @@ export class InvernaderoEditInlineZonasComponent implements OnInit, OnDestroy {
    */
   obtenerSensoresCount(zonaId: number): number {
     const z = this.datosOriginales.zonas.find((x: any) => x.id === zonaId);
-    const count = Array.isArray(z?.sensores) ? z.sensores.length : 0;
+    const count = (z && 'sensores_count' in z)
+      ? (z as any).sensores_count
+      : Array.isArray(z?.sensores) ? z.sensores.length : 0;
     console.log(`[EditarZona] obtenerSensoresCount(${zonaId}) → ${count}`);
     return count;
   }

--- a/tech-farming-frontend/src/app/invernaderos/components/view-invernadero.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/view-invernadero.component.ts
@@ -1385,7 +1385,7 @@ import { AlertService } from '../../alertas/alertas.service';
             descripcion: z.descripcion,
             activo: z.activo,
             creado_en: z.creado_en,
-            sensores_count: Array.isArray(z.sensores) ? z.sensores.length : 0,
+            sensores_count: z.sensores_count ?? (Array.isArray(z.sensores) ? z.sensores.length : 0),
             sensores: z.sensores
           }))
         } as InvernaderoDetalle;
@@ -1417,7 +1417,7 @@ import { AlertService } from '../../alertas/alertas.service';
               descripcion: z.descripcion,
               activo: z.activo,
               creado_en: z.creado_en,
-              sensoresCount: Array.isArray(z.sensores) ? z.sensores.length : 0
+              sensoresCount: (z as any).sensores_count ?? (Array.isArray((z as any).sensores) ? (z as any).sensores.length : 0)
             }));
           }),
           catchError((err) => {

--- a/tech-farming-frontend/src/app/invernaderos/models/invernadero.model.ts
+++ b/tech-farming-frontend/src/app/invernaderos/models/invernadero.model.ts
@@ -7,6 +7,7 @@ export interface Zona {
   descripcion?: string;
   activo: boolean;
   creado_en: string;
+  sensores_count?: number;
   sensores?: Sensor[];  // Lista de sensores en esta zona
 }
 

--- a/tech-farming-frontend/src/app/invernaderos/zona.service.ts
+++ b/tech-farming-frontend/src/app/invernaderos/zona.service.ts
@@ -17,10 +17,13 @@ export class ZonaService {
    * GET /api/invernaderos/:id/zonas
    */
   getZonasByInvernadero(invernaderoId: number): Observable<Zona[]> {
-    return this.http.get<Zona[]>(
-      `${this.baseUrl}/${invernaderoId}/zonas`
-    ).pipe(
-      map(res => Array.isArray(res) ? res : [])  // fallback defensivo
-    );
+    return this.http
+      .get<any[]>(`${this.baseUrl}/${invernaderoId}/zonas`)
+      .pipe(
+        map(res => Array.isArray(res) ? res.map(z => ({
+            ...z,
+            sensores_count: z.sensores_count ?? (Array.isArray(z.sensores) ? z.sensores.length : 0)
+          })) : [])
+      );
   }
 }

--- a/tech-farming-frontend/src/app/models/index.ts
+++ b/tech-farming-frontend/src/app/models/index.ts
@@ -7,6 +7,7 @@ export interface Zona {
   id: number;
   nombre: string;
   invernaderoId: number;
+  sensores_count?: number;
 }
 
 export interface Sensor {


### PR DESCRIPTION
## Summary
- return `sensores_count` for each zone in backend
- propagate count via `ZonaService`
- display count in view components and editing dialogs
- extend `Zona` interfaces with `sensores_count`

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684bb12cf7c0832aba37a447bcef0dda