### PR TITLE
Add simple alert color logic

### DIFF
--- a/tech-farming-backend/app/routes/invernaderos.py
+++ b/tech-farming-backend/app/routes/invernaderos.py
@@ -40,7 +40,7 @@ def listar_invernaderos():
                 SensorParametro.sensor_id.in_(sensor_ids)
             )
 
-            # 5) Contar cuántas alertas ACTIVAS (tanto de tipo “Error” como “Umbral”)
+            # 5) Contar alertas activas (cualquier nivel)
             alertas_activas = db.session.query(func.count(Alerta.id)).filter(
                 Alerta.estado == 'Activa',
                 or_(
@@ -48,6 +48,8 @@ def listar_invernaderos():
                     Alerta.sensor_id.in_(sensor_ids)
                 )
             ).scalar()
+
+            hay_alertas = alertas_activas > 0
 
             # 6) Formatear el texto de “estado”
             if alertas_activas == 0:
@@ -66,6 +68,7 @@ def listar_invernaderos():
                 "zonasActivas":   len(zonas_activas),
                 "sensoresActivos": len(sensores_activos),
                 "estado":         estado,
+                "hayAlertas":     hay_alertas,
                 "zonas": [
                     {
                         "id":         z.id,
@@ -133,7 +136,7 @@ def estados_alerta():
             #     Alerta.estado == 'activo'
             # ).count()
 
-            # AHORA:
+            # AHORA: contar alertas activas sin importar su nivel
             alertas_activas = db.session.query(func.count(Alerta.id)).filter(
                 Alerta.estado == 'Activa',
                 or_(
@@ -141,6 +144,8 @@ def estados_alerta():
                     Alerta.sensor_id.in_(sensor_ids)
                 )
             ).scalar()
+
+            hay_alertas = alertas_activas > 0
 
             if alertas_activas == 0:
                 estado = "Sin alertas"
@@ -151,7 +156,8 @@ def estados_alerta():
 
             result.append({
                 "id": inv.id,
-                "estado": estado
+                "estado": estado,
+                "hayAlertas": hay_alertas
             })
 
         return jsonify(result), 200

--- a/tech-farming-frontend/src/app/invernaderos/components/invernadero-card-list.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/invernadero-card-list.component.ts
@@ -18,10 +18,8 @@ import { Invernadero } from '../models/invernadero.model';
             <span
               class="badge badge-sm"
               [ngClass]="{
-                'badge-success': inv.estado === 'Activo',
-                'badge-warning': inv.estado === 'Inactivo',
-                'badge-error':   inv.estado === 'Mantenimiento',
-                'badge-neutral': inv.estado === 'Sin sensores'
+                'badge-error': inv.hayAlertas,
+                'badge-success': !inv.hayAlertas
               }"
             >{{ inv.estado }}</span>
           </div>

--- a/tech-farming-frontend/src/app/invernaderos/components/invernadero-table.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/invernadero-table.component.ts
@@ -28,10 +28,8 @@ import { Invernadero } from '../models/invernadero.model';
               <span
                 class="badge badge-md"
                 [ngClass]="{
-                  'badge-success': inv.estado === 'Activo',
-                  'badge-warning': inv.estado === 'Inactivo',
-                  'badge-error':   inv.estado === 'Mantenimiento',
-                  'badge-outline': inv.estado === 'Sin sensores'
+                  'badge-error': inv.hayAlertas,
+                  'badge-success': !inv.hayAlertas
                 }"
               >
                 {{ inv.estado }}

--- a/tech-farming-frontend/src/app/invernaderos/invernaderos.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/invernaderos.component.ts
@@ -274,7 +274,10 @@ export class InvernaderosComponent implements OnInit, OnDestroy {
           // Solo actualizamos el “estado” en cada invernadero visible
           estados.forEach((est: any) => {
             const inv = this.invernaderos.find(i => i.id === est.id);
-            if (inv) inv.estado = est.estado || 'Sin alertas';
+            if (inv) {
+              inv.estado = est.estado || 'Sin alertas';
+              inv.hayAlertas = est.hayAlertas ?? false;
+            }
           });
         }
       }),

--- a/tech-farming-frontend/src/app/invernaderos/invernaderos.service.ts
+++ b/tech-farming-frontend/src/app/invernaderos/invernaderos.service.ts
@@ -89,11 +89,11 @@ export class InvernaderoService {
   getEstadosAlerta(
     page: number,
     pageSize: number
-  ): Observable<Array<{ id: number; estado: string }>> {
+  ): Observable<Array<{ id: number; estado: string; hayAlertas: boolean }>> {
     const params = new HttpParams()
       .set('page', page)
       .set('pageSize', pageSize);
-    return this.http.get<Array<{ id: number; estado: string }>>(
+    return this.http.get<Array<{ id: number; estado: string; hayAlertas: boolean }>>(
       `${this.baseUrl}/estados-alerta`,
       { params }
     );

--- a/tech-farming-frontend/src/app/invernaderos/models/invernadero.model.ts
+++ b/tech-farming-frontend/src/app/invernaderos/models/invernadero.model.ts
@@ -20,4 +20,5 @@ export interface Invernadero {
   sensoresActivos?: number;
   sensoresTotales?: number;
   estado?: string;  // ej: "2 alertas activas" o "Sin alertas"
+  hayAlertas?: boolean;
 }


### PR DESCRIPTION
## Summary
- backend `invernaderos` endpoints only return a boolean `hayAlertas`
- greenhouse table and card list badges show red when `hayAlertas` is true and green otherwise
- updated model, service and refresh logic to use the new field

## Testing
- `npm test` *(fails: No binary for Chrome)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684bb0941134832a9f1b71b5b4c1bdc6