### PR TITLE
Fix red alert card border

### DIFF
--- a/tech-farming-frontend/src/app/dashboard/components/alert-card.component.ts
+++ b/tech-farming-frontend/src/app/dashboard/components/alert-card.component.ts
@@ -9,10 +9,10 @@ import { CommonModule } from '@angular/common';
   template: `
     <div
       tabindex="0"
-      class="flex items-start rounded-lg p-4 shadow-sm transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-1"
+      class="flex items-start rounded-lg p-4 shadow-sm transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-1 border"
       [ngClass]="{
-        'border border-error bg-error/10 hover:bg-error/20 dark:bg-error/20 dark:hover:bg-error/30 focus:ring-error focus:ring-offset-base-100': nivel === 'critica',
-        'border border-warning bg-warning/10 hover:bg-warning/20 dark:bg-warning/20 dark:hover:bg-warning/30 focus:ring-warning focus:ring-offset-base-100': nivel === 'advertencia'
+        'border-error bg-error/10 hover:bg-error/20 dark:bg-error/20 dark:hover:bg-error/30 focus:ring-error focus:ring-offset-base-100': nivel === 'critica',
+        'border-warning bg-warning/10 hover:bg-warning/20 dark:bg-warning/20 dark:hover:bg-warning/30 focus:ring-warning focus:ring-offset-base-100': nivel === 'advertencia'
       }"
       role="alert"
       aria-live="polite"


### PR DESCRIPTION
## Summary
- revert mistaken global alert style
- always show a border on critical alert cards

## Testing
- `npm test --silent -- --browsers=ChromeHeadless --watch=false` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_684bb17459ac832ab69b50458aeed0f0