### PR TITLE
Fix timezone for creation timestamps

### DIFF
--- a/tech-farming-backend/app/config/__init__.py
+++ b/tech-farming-backend/app/config/__init__.py
@@ -2,6 +2,7 @@ import os
 from dotenv import load_dotenv
 from influxdb_client import InfluxDBClient, Point
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 # Cargar las variables del archivo .env
 load_dotenv()
@@ -35,7 +36,7 @@ def escribir_dato(sensor_id, parametro, valor):
         .tag("sensor_id", sensor_id)
         .field("parametro", parametro)
         .field("valor", valor)
-        .time(datetime.utcnow())
+        .time(datetime.now(ZoneInfo("America/Santiago")))
     )
 
     if Config.client:

--- a/tech-farming-backend/app/models/alerta.py
+++ b/tech-farming-backend/app/models/alerta.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from app import db
 
 class Alerta(db.Model):
@@ -11,7 +12,11 @@ class Alerta(db.Model):
     tipo = db.Column(db.String(50), nullable=False)
     mensaje = db.Column(db.Text, nullable=False)
     valor_detectado = db.Column(db.Numeric, nullable=True)
-    fecha_hora = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    fecha_hora = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(ZoneInfo("America/Santiago")),
+        nullable=False
+    )
     nivel = db.Column(db.String(20))
     estado = db.Column(db.String(20), default="activo", nullable=False)
     fecha_resolucion = db.Column(db.DateTime, nullable=True)

--- a/tech-farming-backend/app/models/configuracion_umbral.py
+++ b/tech-farming-backend/app/models/configuracion_umbral.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from sqlalchemy.orm import validates
 from sqlalchemy import CheckConstraint
 from app import db
@@ -15,6 +16,9 @@ class ConfiguracionUmbral(db.Model):
     critico_min = db.Column(db.Numeric)
     critico_max = db.Column(db.Numeric)
 
-    creado_en = db.Column(db.DateTime, default=datetime.utcnow)
+    creado_en = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(ZoneInfo("America/Santiago"))
+    )
     activo = db.Column(db.Boolean, default=True)
 

--- a/tech-farming-backend/app/models/invernadero.py
+++ b/tech-farming-backend/app/models/invernadero.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from app import db
 
 class Invernadero(db.Model):
@@ -6,7 +7,10 @@ class Invernadero(db.Model):
     id          = db.Column(db.Integer, primary_key=True)
     nombre      = db.Column(db.String(100), nullable=False)
     descripcion = db.Column(db.Text)
-    creado_en   = db.Column(db.DateTime, default=datetime.utcnow)
+    creado_en   = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(ZoneInfo("America/Santiago"))
+    )
 
     zonas       = db.relationship(
                      'Zona',

--- a/tech-farming-backend/app/models/sensor.py
+++ b/tech-farming-backend/app/models/sensor.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from app import db
 
 class Sensor(db.Model):
@@ -10,7 +11,10 @@ class Sensor(db.Model):
     descripcion = db.Column(db.Text)
     estado = db.Column(db.String(20), nullable=False)
     fecha_instalacion = db.Column(db.Date, nullable=False)
-    creado_en = db.Column(db.DateTime, default=datetime.utcnow)
+    creado_en = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(ZoneInfo("America/Santiago"))
+    )
     tipo_sensor_id = db.Column(db.Integer, db.ForeignKey('tipos_sensor.id'), nullable=False)
     token = db.Column(db.String(64), unique=True, nullable=False)
 

--- a/tech-farming-backend/app/models/usuario.py
+++ b/tech-farming-backend/app/models/usuario.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from app import db
 
 class Usuario(db.Model):
@@ -12,7 +13,10 @@ class Usuario(db.Model):
     rol_id = db.Column(db.Integer, db.ForeignKey('roles.id'), nullable=False)
     usuario_admin_id = db.Column(db.Integer, db.ForeignKey('usuarios.id'), nullable=True)
     supabase_uid = db.Column(db.UUID(as_uuid=True), unique=True, nullable=False)
-    fecha_creacion = db.Column(db.DateTime, default=datetime.utcnow)
+    fecha_creacion = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(ZoneInfo("America/Santiago"))
+    )
 
     administrador = db.relationship('Usuario', remote_side=[id], backref='trabajadores', lazy=True)
     permisos = db.relationship('UsuarioPermiso', backref='usuario', lazy=True)

--- a/tech-farming-backend/app/models/zona.py
+++ b/tech-farming-backend/app/models/zona.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from app import db
 
 class Zona(db.Model):
@@ -7,7 +8,10 @@ class Zona(db.Model):
     invernadero_id = db.Column(db.Integer, db.ForeignKey('invernaderos.id'), nullable=False)
     nombre         = db.Column(db.String(100), nullable=False)
     descripcion    = db.Column(db.Text)
-    creado_en      = db.Column(db.DateTime, default=datetime.utcnow)
+    creado_en      = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(ZoneInfo("America/Santiago"))
+    )
     activo         = db.Column(db.Boolean, default=True)
 
     invernadero   = db.relationship(

--- a/tech-farming-backend/app/queries/alerta_queries.py
+++ b/tech-farming-backend/app/queries/alerta_queries.py
@@ -227,7 +227,7 @@ def verificar_sensores_desconectados(app, minutos: int = 10):
     """
     with app.app_context():
 
-        ahora = datetime.utcnow()
+        ahora = datetime.now(ZoneInfo("America/Santiago"))
         sensores = Sensor.query.filter_by(estado="Activo").all()
         sensores_inactivos = []
 

--- a/tech-farming-backend/app/routes/alertas.py
+++ b/tech-farming-backend/app/routes/alertas.py
@@ -4,6 +4,7 @@ from app.queries.alerta_queries import listar_alertas
 from app.models.alerta import Alerta
 from app.utils.auth_supabase import usuario_autenticado_requerido
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 router = Blueprint('alertas', __name__)
 
@@ -41,7 +42,7 @@ def resolver_alerta(alerta_id):
         usuario = g.usuario
         
         alerta.estado = "Resuelta"
-        alerta.fecha_resolucion = datetime.utcnow()
+        alerta.fecha_resolucion = datetime.now(ZoneInfo("America/Santiago"))
         alerta.resuelta_por = usuario.id
         db.session.commit()
 

--- a/tech-farming-backend/app/routes/predict_routes.py
+++ b/tech-farming-backend/app/routes/predict_routes.py
@@ -5,6 +5,7 @@ import pandas as pd
 import joblib
 from flask import Blueprint, request, jsonify
 from datetime import timedelta, datetime
+from zoneinfo import ZoneInfo
 
 from app.config import Config
 from app.queries.prediction_queries import obtener_serie_prediccion
@@ -99,7 +100,7 @@ def predict_from_influx():
         return jsonify({"error": f"parametro inválido (elegir uno de {validos})"}), 400
 
     # Rango de consulta: últimas 24h
-    now = datetime.utcnow()
+    now = datetime.now(ZoneInfo("America/Santiago"))
     desde = (now - timedelta(hours=24)).strftime("%Y-%m-%dT%H:%M:%SZ")
     hasta =  now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -175,7 +176,7 @@ def predict_from_influx():
     avg_fut  = sum(p["value"] for p in future)     / len(future)
     diff_pct = ((avg_fut-avg_hist)/avg_hist)*100
     summary = {
-        "updated": datetime.utcnow().isoformat(),
+        "updated": datetime.now(ZoneInfo("America/Santiago")).isoformat(),
         "text":    f"Predicción de {horas}h de {parametro} en inv.{inv_id}",
         "model":   mname
     }

--- a/tech-farming-backend/app/routes/sensores.py
+++ b/tech-farming-backend/app/routes/sensores.py
@@ -1,6 +1,7 @@
 import traceback
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 from uuid import uuid4
 from flask import Blueprint, g, request, jsonify, abort, current_app
 from sqlalchemy.orm import joinedload
@@ -164,7 +165,7 @@ def crear_sensor():
         nombre=nombre,
         descripcion=descripcion,
         estado=estado,
-        fecha_instalacion=datetime.utcnow(),
+        fecha_instalacion=datetime.now(ZoneInfo("America/Santiago")).date(),
         tipo_sensor_id=tipo_sensor_id,
         token=token
     )

--- a/tech-farming-backend/app/routes/usuarios.py
+++ b/tech-farming-backend/app/routes/usuarios.py
@@ -4,6 +4,7 @@ from app.models.usuario import Usuario
 from app.models.usuario_permiso import UsuarioPermiso
 from app.models.rol import Rol
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from supabase import create_client
 from app.utils.auth_supabase import usuario_autenticado_requerido
 import os
@@ -31,7 +32,7 @@ def crear_usuario_desde_supabase():
         supabase_uid=supabase_uid,
         email=email,
         rol_id=1,
-        fecha_creacion=datetime.utcnow()
+        fecha_creacion=datetime.now(ZoneInfo("America/Santiago"))
     )
     db.session.add(nuevo_usuario)
     db.session.flush()
@@ -95,7 +96,7 @@ def invitar_usuario():
         telefono=telefono,
         rol_id=2,
         supabase_uid=supabase_uid,
-        fecha_creacion=datetime.utcnow()
+        fecha_creacion=datetime.now(ZoneInfo("America/Santiago"))
     )
     db.session.add(nuevo_usuario)
     db.session.flush()

--- a/tech-farming-backend/seed_two_sensors.py
+++ b/tech-farming-backend/seed_two_sensors.py
@@ -3,6 +3,7 @@
 import random
 import time
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 from influxdb_client import Point
 
 # ---------------------------------------------------
@@ -15,14 +16,14 @@ def escribir_dato(sensor_id, parametro, valor, ts: datetime = None):
       - tag "sensor_id" = sensor_id (string)
       - field "parametro" = parametro (string: "temperature" o "humidity")
       - field "valor" = valor (float)
-      - time = ts (si se pasa) o datetime.utcnow() si ts es None
+      - time = ts (si se pasa) o la hora actual en Chile si ts es None
     """
     if sensor_id is None or parametro is None or valor is None:
         print("⚠️ Error: sensor_id, parametro y valor son obligatorios")
         return
 
     if ts is None:
-        ts = datetime.utcnow()
+        ts = datetime.now(ZoneInfo("America/Santiago"))
 
     # Importamos Config que ya debe haber sido configurado en tu app.
     from app.config import Config
@@ -54,7 +55,7 @@ def main():
     sensor_ids = [48, 49]
 
     # 1) Punto de inicio: hace 24 horas
-    ahora  = datetime.utcnow()
+    ahora  = datetime.now(ZoneInfo("America/Santiago"))
     inicio = ahora - timedelta(hours=24)
 
     # 2) Intervalo de 30 minutos


### PR DESCRIPTION
## Summary
- ensure all backend timestamps use `America/Santiago`
- update models, routes and utilities to replace `datetime.utcnow`
- adjust seed script to use local timezone

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb1cfaa6c832aa7e4a5b12704e0cb