### PR TITLE
Add delete confirmation modal

### DIFF
--- a/tech-farming-frontend/src/app/admin/components/admin-delete-modal.component.ts
+++ b/tech-farming-frontend/src/app/admin/components/admin-delete-modal.component.ts
@@ -8,6 +8,13 @@ import { AdminService } from '../admin.service';
   standalone: true,
   imports: [CommonModule, FormsModule],
   template: `
+    <div *ngIf="confirmacionVisible" class="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
+      <div class="bg-base-100 p-6 rounded-xl shadow-xl text-center w-[300px] space-y-2 border border-base-300">
+        <h3 class="text-xl font-semibold text-success">✅ ¡Éxito!</h3>
+        <p>{{ mensajeConfirmacion }}</p>
+      </div>
+    </div>
+
     <div class="p-6 bg-base-100 rounded-lg shadow-lg  w-full space-y-4">
       <h2 class="text-xl font-bold text-error">⚠️ Eliminar usuario</h2>
       <p>¿Estás seguro de que quieres eliminar a <strong>{{ nombre }}</strong>?</p>
@@ -35,6 +42,8 @@ export class AdminDeleteModalComponent {
   confirmText = '';
   loading = false;
   errorMessage = '';
+  confirmacionVisible = false;
+  mensajeConfirmacion = '';
   constructor(private svc: AdminService) {}
 
   get canDelete(): boolean {
@@ -46,7 +55,15 @@ export class AdminDeleteModalComponent {
     this.loading = true;
     this.errorMessage = '';
     this.svc.eliminarTrabajador(this.usuarioId).subscribe({
-      next: () => this.deleted.emit(this.usuarioId),
+      next: () => {
+        this.loading = false;
+        this.mensajeConfirmacion = 'Usuario eliminado correctamente.';
+        this.confirmacionVisible = true;
+        setTimeout(() => {
+          this.confirmacionVisible = false;
+          this.deleted.emit(this.usuarioId);
+        }, 2500);
+      },
       error: err => {
         this.loading = false;
         this.errorMessage = err?.error?.error || 'No se pudo eliminar el usuario.';


### PR DESCRIPTION
## Summary
- show confirmation overlay when deleting a user

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684bbf261ee4832a9de63f010aa13b97