### PR TITLE
Unify export buttons

### DIFF
--- a/tech-farming-frontend/src/app/historial/components/historial-header.component.ts
+++ b/tech-farming-frontend/src/app/historial/components/historial-header.component.ts
@@ -1,11 +1,12 @@
 // src/app/historial/components/historial-header.component.ts
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ExportOptionsComponent } from '../../shared/components/export-options.component';
 
 @Component({
   selector: 'app-historial-header',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ExportOptionsComponent],
   template: `
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 my-5 mx-6">
       <!-- Título dinámico -->
@@ -13,29 +14,9 @@ import { CommonModule } from '@angular/common';
         {{ title }}
       </h1>
 
-      <!-- Acción de exportar CSV -->
+      <!-- Acción de exportar -->
       <div class="flex flex-col sm:flex-row gap-2">
-        <button
-          class="btn bg-transparent border-success text-base-content hover:bg-success hover:text-success-content flex items-center gap-2"
-          (click)="exportCsv.emit()"
-          aria-label="Exportar historial a CSV"
-        >
-          <svg
-              class="w-5 h-5 stroke-base-content hover:stroke-success-content "
-              fill="none"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M12 3v12m0 0l-3-3m3 3l3-3M20 21H4a2 2 0 01-2-2V5a2 2 0 012-2h8l8 8v10a2 2 0 01-2 2z"
-              />
-          </svg>
-          <span class="text-base-content group-hover:text-success-content">
-            Exportar CSV
-          </span>
-        </button>
+        <app-export-options (exportar)="exportar.emit($event)"></app-export-options>
       </div>
     </div>
   `
@@ -44,5 +25,5 @@ export class HistorialHeaderComponent {
   /** Texto del título */
   @Input() title = 'Historial';
   /** Emite cuando el usuario clickea exportar */
-  @Output() exportCsv = new EventEmitter<void>();
+  @Output() exportar = new EventEmitter<'pdf' | 'excel' | 'csv'>();
 }

--- a/tech-farming-frontend/src/app/historial/historial.component.ts
+++ b/tech-farming-frontend/src/app/historial/historial.component.ts
@@ -31,7 +31,7 @@ import { HistorialHeaderComponent } from './components/historial-header.componen
 
       <app-historial-header
         [title]="'Historial de Variables'"
-        (exportCsv)="exportCsv()"
+        (exportar)="onExport($event)"
       ></app-historial-header>
       <!-- COMPONENTE DE FILTROS -->
       <app-filtro-global (filtrosSubmit)="onFiltrosAplicados($event)"></app-filtro-global>
@@ -200,17 +200,22 @@ export class HistorialComponent implements OnInit {
   }
 
   /**
-   * Exporta a CSV la serie actual (si existe historial).
+   * Maneja la exportación según el formato elegido.
    */
-  exportCsv() {
+  onExport(format: 'pdf' | 'excel' | 'csv') {
     if (!this.historial) return;
-    const csv = this.historial.series.map(s => `${s.timestamp},${s.value}`).join('\n');
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'historial.csv';
-    a.click();
-    URL.revokeObjectURL(url);
+
+    if (format === 'csv') {
+      const csv = this.historial.series.map(s => `${s.timestamp},${s.value}`).join('\n');
+      const blob = new Blob([csv], { type: 'text/csv' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'historial.csv';
+      a.click();
+      URL.revokeObjectURL(url);
+    } else {
+      console.log(`Exportar ${format} aún no implementado`);
+    }
   }
 }

--- a/tech-farming-frontend/src/app/invernaderos/components/invernadero-header.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/components/invernadero-header.component.ts
@@ -1,10 +1,11 @@
 import { Component, Output, EventEmitter, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ExportOptionsComponent } from '../../shared/components/export-options.component';
 
 @Component({
   selector: 'app-invernadero-header',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ExportOptionsComponent],
   template: `
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 my-5 mx-6">
       <!-- Título -->
@@ -14,28 +15,7 @@ import { CommonModule } from '@angular/common';
 
       <!-- Acciones -->
       <div class="flex flex-col sm:flex-row gap-2">
-        <!-- Botón Exportar PDF -->
-        <button
-          class="btn bg-transparent border-success text-base-content hover:bg-success hover:text-success-content"
-          (click)="exportPdf.emit()"
-          aria-label="Exportar listado de invernaderos a PDF"
-        >
-          <svg
-            class="w-5 h-5 stroke-base-content hover:stroke-success-content"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M12 3v12m0 0l-3-3m3 3l3-3M20 21H4a2 2 0 01-2-2V5a2 2 0 012-2h8l8 8v10a2 2 0 01-2 2z"
-            />
-          </svg>
-          <span class="text-base-content group-hover:text-success-content">
-            Exportar PDF
-          </span>
-        </button>
+        <app-export-options (exportar)="exportar.emit($event)"></app-export-options>
 
         <!-- Botón Añadir Invernadero -->
         <button
@@ -66,6 +46,6 @@ import { CommonModule } from '@angular/common';
 })
 export class InvernaderoHeaderComponent {
   @Input() puedeCrear = false;
-  @Output() create    = new EventEmitter<void>();
-  @Output() exportPdf = new EventEmitter<void>();
+  @Output() create     = new EventEmitter<void>();
+  @Output() exportar = new EventEmitter<'pdf' | 'excel' | 'csv'>();
 }

--- a/tech-farming-frontend/src/app/invernaderos/invernaderos.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/invernaderos.component.ts
@@ -53,8 +53,9 @@ import { ViewInvernaderoComponent } from './components/view-invernadero.componen
     <section class="space-y-6">
 
       <!-- HEADER + BOTON “Crear” -->
-      <app-invernadero-header 
+      <app-invernadero-header
         (create)="open('create')"
+        (exportar)="onExport($event)"
         [puedeCrear]="puedeCrear">
       </app-invernadero-header>
 
@@ -430,6 +431,21 @@ export class InvernaderosComponent implements OnInit, OnDestroy {
     if (this.loadCount === 0) {
       this.loading = false;
       this.initialLoad = false;
+    }
+  }
+
+  onExport(format: 'pdf' | 'excel' | 'csv') {
+    if (format === 'csv') {
+      const csv = this.invernaderos.map(i => `${i.id},${i.nombre}`).join('\n');
+      const blob = new Blob([csv], { type: 'text/csv' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'invernaderos.csv';
+      a.click();
+      URL.revokeObjectURL(url);
+    } else {
+      console.log(`Exportar ${format} aún no implementado`);
     }
   }
 

--- a/tech-farming-frontend/src/app/sensores/components/sensor-header.component.ts
+++ b/tech-farming-frontend/src/app/sensores/components/sensor-header.component.ts
@@ -1,11 +1,12 @@
 // src/app/sensores/components/sensor-header.component.ts
 import { Component, Output, EventEmitter, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ExportOptionsComponent } from '../../shared/components/export-options.component';
 
 @Component({
   selector: 'app-sensor-header',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ExportOptionsComponent],
   template: `
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 my-5 mx-6">
       <!-- Título -->
@@ -15,28 +16,7 @@ import { CommonModule } from '@angular/common';
 
       <!-- Acciones -->
       <div class="flex flex-col sm:flex-row gap-2">
-        <!-- Botón Exportar PDF -->
-        <button
-          class="btn bg-transparent border-success text-base-content hover:bg-success hover:text-success-content "
-          (click)="exportPdf.emit()"
-          aria-label="Exportar listado de sensores a PDF"
-        >
-          <svg
-            class="w-5 h-5 stroke-base-content hover:stroke-success-content "
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M12 3v12m0 0l-3-3m3 3l3-3M20 21H4a2 2 0 01-2-2V5a2 2 0 012-2h8l8 8v10a2 2 0 01-2 2z"
-            />
-          </svg>
-          <span class="text-base-content group-hover:text-success-content ">
-            Exportar PDF
-          </span>
-        </button>
+        <app-export-options (exportar)="exportar.emit($event)"></app-export-options>
 
         <!-- Botón Añadir Sensor -->
         <button
@@ -67,6 +47,6 @@ import { CommonModule } from '@angular/common';
 })
 export class SensorHeaderComponent {
   @Input() puedeCrear = false;
-  @Output() create    = new EventEmitter<void>();
-  @Output() exportPdf = new EventEmitter<void>();
+  @Output() create     = new EventEmitter<void>();
+  @Output() exportar = new EventEmitter<'pdf' | 'excel' | 'csv'>();
 }

--- a/tech-farming-frontend/src/app/sensores/sensores.component.ts
+++ b/tech-farming-frontend/src/app/sensores/sensores.component.ts
@@ -50,6 +50,7 @@ import { NotificationService }       from '../shared/services/notification.servi
     <!-- HEADER -->
     <app-sensor-header
       (create)="modal.openModal('create')"
+      (exportar)="onExport($event)"
       [puedeCrear]="puedeCrear">
     </app-sensor-header>
 
@@ -417,6 +418,21 @@ onEdited(updated: Sensor) {
   onCloseModal() {
     this.modal.closeWithAnimation();
     this.loadPage(this.currentPage);
+  }
+
+  onExport(format: 'pdf' | 'excel' | 'csv') {
+    if (format === 'csv') {
+      const csv = this.sensoresConLectura.map(s => `${s.id},${s.nombre}`).join('\n');
+      const blob = new Blob([csv], { type: 'text/csv' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'sensores.csv';
+      a.click();
+      URL.revokeObjectURL(url);
+    } else {
+      console.log(`Exportar ${format} aún no implementado`);
+    }
   }
 
   trackBySensorId(_i: any, s: Sensor) {

--- a/tech-farming-frontend/src/app/shared/components/export-options.component.ts
+++ b/tech-farming-frontend/src/app/shared/components/export-options.component.ts
@@ -1,0 +1,33 @@
+import { Component, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-export-options',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="dropdown">
+      <button tabindex="0"
+              class="btn bg-transparent border-success text-base-content hover:bg-success hover:text-success-content">
+        <svg class="w-5 h-5 stroke-base-content hover:stroke-success-content"
+             fill="none" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M12 3v12m0 0l-3-3m3 3l3-3M20 21H4a2 2 0 01-2-2V5a2 2 0 012-2h8l8 8v10a2 2 0 01-2 2z"/>
+        </svg>
+        <span class="text-base-content group-hover:text-success-content">Exportar</span>
+      </button>
+      <ul tabindex="0" class="menu dropdown-content mt-2 p-2 shadow-lg bg-base-100 rounded-box w-32">
+        <li><a (click)="onSelect('pdf')">PDF</a></li>
+        <li><a (click)="onSelect('excel')">Excel</a></li>
+        <li><a (click)="onSelect('csv')">CSV</a></li>
+      </ul>
+    </div>
+  `
+})
+export class ExportOptionsComponent {
+  @Output() exportar = new EventEmitter<'pdf' | 'excel' | 'csv'>();
+
+  onSelect(format: 'pdf' | 'excel' | 'csv') {
+    this.exportar.emit(format);
+  }
+}


### PR DESCRIPTION
## Summary
- add ExportOptions shared component
- use ExportOptions in sensor, greenhouse and history headers
- implement CSV export in sensors and greenhouses
- connect unified export actions in pages

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684bca395fc0832aae2a2a03c0151660