### PR TITLE
Load Supabase key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,9 @@ La solución integra lectura de sensores que miden:
 Algunas alertas históricas se generaron antes de contar con el campo
 `sensor_id`. Por compatibilidad, el listado verifica tanto `Alerta.sensor_id`
 como el sensor asociado al `sensor_parametro` cuando se filtra por sensor.
+
+## 🌐 Configuración de entorno
+
+La clave de acceso de Supabase ya no se incluye en el código fuente. Antes de
+iniciar el frontend se debe establecer la variable de entorno `SUPABASE_KEY`,
+que será leída en tiempo de ejecución para crear el cliente de Supabase.

--- a/tech-farming-frontend/src/app/services/supabase.service.ts
+++ b/tech-farming-frontend/src/app/services/supabase.service.ts
@@ -2,6 +2,16 @@ import { inject, Injectable, NgZone } from '@angular/core';
 import { SupabaseClient, createClient } from '@supabase/supabase-js';
 import { environment } from '../../environments/environment';
 
+function loadSupabaseKey(): string {
+  if (typeof window !== 'undefined' && (window as any).SUPABASE_KEY) {
+    return (window as any).SUPABASE_KEY as string;
+  }
+  if (typeof process !== 'undefined' && process.env && process.env['SUPABASE_KEY']) {
+    return process.env['SUPABASE_KEY'] as string;
+  }
+  throw new Error('SUPABASE_KEY not defined');
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -11,7 +21,7 @@ export class SupabaseService {
 
   constructor() {
     this.supabase = this.ngZone.runOutsideAngular(() =>
-      createClient(environment.supabaseUrl, environment.supabaseKey)
+      createClient(environment.supabaseUrl, loadSupabaseKey())
     );
   }
 }

--- a/tech-farming-frontend/src/environments/environment.prod.ts
+++ b/tech-farming-frontend/src/environments/environment.prod.ts
@@ -1,5 +1,4 @@
 export const environment = {
   production: true,
   supabaseUrl: 'https://efejsncxndycbgfyhvcv.supabase.co',
-  supabaseKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVmZWpzbmN4bmR5Y2JnZnlodmN2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDMwMzE0NjYsImV4cCI6MjA1ODYwNzQ2Nn0.CxHCTJkNFrT4BOZCnFTB3pylfxc-2w-mPtS5UXs7nHs'
 };

--- a/tech-farming-frontend/src/environments/environment.ts
+++ b/tech-farming-frontend/src/environments/environment.ts
@@ -1,5 +1,4 @@
 export const environment = {
   production: false,
   supabaseUrl: 'https://efejsncxndycbgfyhvcv.supabase.co',
-  supabaseKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVmZWpzbmN4bmR5Y2JnZnlodmN2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDMwMzE0NjYsImV4cCI6MjA1ODYwNzQ2Nn0.CxHCTJkNFrT4BOZCnFTB3pylfxc-2w-mPtS5UXs7nHs'
 };


### PR DESCRIPTION
## Summary
- read Supabase key at runtime instead of shipping it in environment.ts
- document the SUPABASE_KEY variable for the frontend

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684bd09ba05c832a9492394a4e1fda8d