### PR TITLE
Fix historial day range handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ Algunas alertas históricas se generaron antes de contar con el campo
 `sensor_id`. Por compatibilidad, el listado verifica tanto `Alerta.sensor_id`
 como el sensor asociado al `sensor_parametro` cuando se filtra por sensor.
 
+### Rango de fechas en `/api/historial`
+
+Si se envían las fechas `desde` y `hasta` con el mismo día y ambas en
+`00:00:00`, el backend interpretará que se desea consultar todo ese día y
+extenderá internamente el parámetro `hasta` 24 horas. El componente de filtros
+del frontend ajusta automáticamente la hora de `fechaHasta` a `23:59:59` para
+cubrir la jornada completa.
+
 ## 🌐 Configuración de entorno
 
 La clave de acceso de Supabase ya no se incluye en el código fuente. Antes de

--- a/tech-farming-backend/app/routes/historial.py
+++ b/tech-farming-backend/app/routes/historial.py
@@ -2,6 +2,7 @@
 
 from flask import Blueprint, request, jsonify, current_app, abort
 from dateutil.parser import isoparse
+from datetime import time, timedelta
 from influxdb_client.client.exceptions import InfluxDBError
 from app.queries.historial_queries import obtener_historial as helper_historial
 from app.models.tipo_parametro import TipoParametro as TipoParametroModel
@@ -28,8 +29,17 @@ def get_historial():
         dt_hasta_obj = isoparse(hasta_s)
     except (ValueError, TypeError):
         abort(400, description="Formato de fecha inválido. Usa ISO 8601, p.ej. 2025-05-21T12:00:00Z")
+
     if dt_desde_obj > dt_hasta_obj:
         abort(400, description="'desde' no puede ser posterior a 'hasta'")
+
+    # Si ambos timestamps son la misma fecha y a medianoche,
+    # extendemos 'hasta' un día para cubrir esa jornada completa.
+    if (
+        dt_desde_obj.date() == dt_hasta_obj.date()
+        and dt_desde_obj.time().replace(tzinfo=None) == dt_hasta_obj.time().replace(tzinfo=None) == time(0, 0)
+    ):
+        dt_hasta_obj += timedelta(days=1)
 
     # Convertimos de nuevo a ISO para pasarlo al helper
     dt_desde = dt_desde_obj.isoformat()

--- a/tech-farming-frontend/src/app/historial/components/filtro.component.ts
+++ b/tech-farming-frontend/src/app/historial/components/filtro.component.ts
@@ -324,13 +324,17 @@ export class FiltroComponent implements OnInit, OnDestroy {
     }
 
     const v = this.form.value;
+    const hasta = new Date(v.hasta);
+    // Al enviar solo la fecha "hasta" se ajusta a las 23:59 para cubrir el día completo
+    hasta.setHours(23, 59, 59, 999);
+
     const params: HistorialParams = {
       invernaderoId:   Number(v.invernaderoId),
       zonaId:          v.zonaId != null ? Number(v.zonaId) : undefined,
       sensorId:        v.sensorId != null ? Number(v.sensorId) : undefined,
       tipoParametroId: Number(v.tipoParametroId),
       fechaDesde:      new Date(v.desde),
-      fechaHasta:      new Date(v.hasta)
+      fechaHasta:      hasta
     };
 
     this.filtrosSubmit.emit(params);


### PR DESCRIPTION
## Summary
- expand `/api/historial` `hasta` by a day when the range is the same date at midnight
- set frontend `fechaHasta` to 23:59:59 so the day is fully covered
- document how the backend interprets same-day ranges

## Testing
- `python -m py_compile tech-farming-backend/app/routes/historial.py`

------
https://chatgpt.com/codex/tasks/task_e_684bd8d13890832a8b72349139ee439f