### PR TITLE
Fix invernadero export

### DIFF
--- a/tech-farming-frontend/src/app/invernaderos/invernaderos.component.ts
+++ b/tech-farming-frontend/src/app/invernaderos/invernaderos.component.ts
@@ -437,7 +437,15 @@ export class InvernaderosComponent implements OnInit, OnDestroy {
   }
 
   onExport(format: 'pdf' | 'excel' | 'csv') {
-    const data = this.invernaderos.map(i => ({ id: i.id, nombre: i.nombre }));
+    const data = this.invernaderos.map(i => ({
+      id: i.id,
+      nombre: i.nombre,
+      descripcion: i.descripcion ?? '',
+      zonasActivas: i.zonasActivas ?? 0,
+      sensoresActivos: i.sensoresActivos ?? 0,
+      estado: i.estado ?? '',
+      creado: new Date(i.creado_en).toLocaleString()
+    }));
     switch (format) {
       case 'csv':
         this.exportSvc.toCsv(data, 'invernaderos');

--- a/tech-farming-frontend/src/app/shared/services/export.service.ts
+++ b/tech-farming-frontend/src/app/shared/services/export.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { saveAs } from 'file-saver';
 import * as XLSX from 'xlsx';
 import jsPDF from 'jspdf';
-import 'jspdf-autotable';
+import autoTable from 'jspdf-autotable';
 
 @Injectable({ providedIn: 'root' })
 export class ExportService {
@@ -39,7 +39,7 @@ export class ExportService {
     if (data && data.length > 0) {
       const headers = Object.keys(data[0]);
       const rows = data.map(row => headers.map(h => row[h]));
-      (doc as any).autoTable({ head: [headers], body: rows });
+      autoTable(doc, { head: [headers], body: rows });
     } else {
       doc.text('No data', 10, 10);
     }


### PR DESCRIPTION
## Summary
- fix ExportService PDF generation by using `autoTable` correctly
- include extra columns when exporting invernaderos

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_684bd8246d5c832a8021ea5f420f8e6e