### PR TITLE
Improve Historial auto filter

### DIFF
--- a/tech-farming-frontend/src/app/historial/components/filtro.component.ts
+++ b/tech-farming-frontend/src/app/historial/components/filtro.component.ts
@@ -225,32 +225,44 @@ export class FiltroComponent implements OnInit, OnDestroy {
 
   constructor(private historialService: HistorialService) {}
 
+  private invLoaded = false;
+  private paramLoaded = false;
+  private defaultsApplied = false;
+
   ngOnInit() {
     // 1) Inicializamos el FormGroup con validadores:
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setDate(today.getDate() - 1);
+
     this.form = new FormGroup({
       invernaderoId:   new FormControl<number | null>(null, Validators.required),
       zonaId:          new FormControl<number | null>(null),
       sensorId:        new FormControl<number | null>(null),
       tipoParametroId: new FormControl<number | null>(null, Validators.required),
-      desde:           new FormControl<string>(this.formatDate(new Date()), Validators.required),
-      hasta:           new FormControl<string>(this.formatDate(new Date()), Validators.required)
+      desde:           new FormControl<string>(this.formatDate(yesterday), Validators.required),
+      hasta:           new FormControl<string>(this.formatDate(today), Validators.required)
     }, { validators: this.rangoValidator() });
 
     // 2) Cargar Invernaderos y parámetros básicos
     this.historialService.getInvernaderos().subscribe(list => {
       this.invernaderos = list;
-      if (list.length === 1) {
-        // Si sólo hay un invernadero, auto-seleccionamos
+      if (list.length > 0) {
+        // Seleccionamos por defecto el primero
         this.form.get('invernaderoId')!.setValue(list[0].id);
       }
+      this.invLoaded = true;
+      this.tryAutoApply();
     });
 
     this.historialService.getTiposParametro().subscribe(list => {
       this.tiposParametro = list;
-      if (list.length === 1) {
-        // Si sólo hay un parámetro, auto-seleccionamos
+      if (list.length > 0) {
+        // Seleccionamos por defecto el primero
         this.form.get('tipoParametroId')!.setValue(list[0].id);
       }
+      this.paramLoaded = true;
+      this.tryAutoApply();
     });
 
     // 3) Suscripción a cambios en invernadero → cargar Zonas
@@ -334,6 +346,16 @@ export class FiltroComponent implements OnInit, OnDestroy {
     };
 
     this.filtrosSubmit.emit(params);
+  }
+
+  /**
+   * Aplica filtros automáticamente cuando se cargan las listas iniciales.
+   */
+  private tryAutoApply() {
+    if (!this.defaultsApplied && this.invLoaded && this.paramLoaded && this.form.valid) {
+      this.defaultsApplied = true;
+      this.aplicarFiltros();
+    }
   }
 
   /**

--- a/tech-farming-frontend/src/app/historial/historial.component.ts
+++ b/tech-farming-frontend/src/app/historial/historial.component.ts
@@ -46,11 +46,7 @@ import autoTable from 'jspdf-autotable';
 
         <!-- Spinner semitransparente (cargando) -->
         <div *ngIf="isLoading" class="absolute inset-0 flex items-center justify-center bg-base-200/50 z-20">
-          <svg class="animate-spin h-10 w-10 text-success" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"></path>
-          </svg>
-          <span class="ml-2 text-base-content/70">Cargando datos…</span>
+          <span class="loading loading-spinner text-success"></span>
         </div>
 
         <!-- Banner “No hay datos” mejorado -->


### PR DESCRIPTION
## Summary
- make filtro auto-apply once default data loads

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684bd8885f74832aaa212b54485a5bf4