### PR TITLE
Fix dashboard chart colors on theme change

### DIFF
--- a/tech-farming-frontend/src/app/dashboard/components/line-chart.component.ts
+++ b/tech-farming-frontend/src/app/dashboard/components/line-chart.component.ts
@@ -40,6 +40,7 @@ export class LineChartComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private chartInstance!: Chart<'line', number[], string>;
   public chartReady = false;
+  private themeObserver?: MutationObserver;
 
   ngOnInit(): void {
     // No se crea el gráfico aquí porque el canvas aún no está en el DOM
@@ -48,11 +49,17 @@ export class LineChartComponent implements OnInit, AfterViewInit, OnDestroy {
   ngAfterViewInit(): void {
     // Crear el gráfico cuando el canvas esté disponible
     this.createChart();
+    this.themeObserver = new MutationObserver(() => this.applyThemeColors());
+    this.themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme']
+    });
   }
 
   private createChart(): void {
     const ctx = this.chartCanvas.nativeElement.getContext('2d') as ChartItem;
-    const isDarkMode = document.documentElement.classList.contains('dark');
+    const isDarkMode =
+      document.documentElement.getAttribute('data-theme') === 'dark';
 
     // Obtener colores de variables CSS definidas por DaisyUI / Tailwind y normalizarlos
     const successColor = this.normalizeColor(
@@ -171,6 +178,7 @@ export class LineChartComponent implements OnInit, AfterViewInit, OnDestroy {
     };
 
     this.chartInstance = new Chart(ctx, config);
+    this.applyThemeColors();
 
     // Una vez creado, ocultamos el spinner
     this.chartReady = true;
@@ -247,6 +255,63 @@ export class LineChartComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   /**
+   * Actualiza los colores del gráfico en función del tema activo de DaisyUI.
+   */
+  private applyThemeColors(): void {
+    if (!this.chartInstance) return;
+
+    const isDarkMode =
+      document.documentElement.getAttribute('data-theme') === 'dark';
+
+    const successColor = this.normalizeColor(
+      this.getTailwindColor('--color-success'),
+      '#2B6B4A'
+    );
+    const infoColor = this.normalizeColor(
+      this.getTailwindColor('--color-info'),
+      '#3182CE'
+    );
+    const secondaryColor = this.normalizeColor(
+      this.getTailwindColor('--color-secondary'),
+      '#4C51BF'
+    );
+    const baseTextColor = this.normalizeColor(
+      this.getTailwindColor('--color-base-content'),
+      isDarkMode ? '#FFFFFF' : '#333333'
+    );
+
+    let borderColor = successColor;
+    let backgroundColor = this.hexToRgba(successColor, 0.2);
+    if (this.variable === 'Humedad') {
+      borderColor = infoColor;
+      backgroundColor = this.hexToRgba(infoColor, 0.2);
+    } else if (this.variable === 'Nitrógeno') {
+      borderColor = secondaryColor;
+      backgroundColor = this.hexToRgba(secondaryColor, 0.2);
+    }
+
+    const dataset = this.chartInstance.data.datasets[0] as any;
+    dataset.borderColor = borderColor;
+    dataset.backgroundColor = backgroundColor;
+    dataset.pointHoverBackgroundColor = borderColor;
+    dataset.pointHoverBorderColor = baseTextColor;
+
+    const scales = this.chartInstance.options.scales!;
+    const x = scales['x'] as any;
+    const y = scales['y'] as any;
+    x.ticks.color = baseTextColor;
+    y.ticks.color = baseTextColor;
+    y.grid.color = isDarkMode ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.05)';
+
+    if (this.chartInstance.options.plugins?.tooltip) {
+      (this.chartInstance.options.plugins.tooltip as any).backgroundColor =
+        isDarkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.7)';
+    }
+
+    this.chartInstance.update();
+  }
+
+  /**
    * Permite actualizar los datos (invocado desde el componente padre).
    */
   public actualizarData(
@@ -288,5 +353,6 @@ export class LineChartComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.chartInstance) {
       this.chartInstance.destroy();
     }
+    this.themeObserver?.disconnect();
   }
 }


### PR DESCRIPTION
## Summary
- observe theme changes for dashboard chart colors
- apply DaisyUI theme rules after chart creation
- use `data-theme` to detect dark mode

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684bddedba20832a8f02326d4716046c