### PR TITLE
Fix remaining localhost reference for predictions API

### DIFF
--- a/tech-farming-frontend/src/app/predicciones/predicciones.service.ts
+++ b/tech-farming-frontend/src/app/predicciones/predicciones.service.ts
@@ -2,6 +2,7 @@
 
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { Observable, map } from 'rxjs';
 
 import {
@@ -13,7 +14,7 @@ import {
 
 @Injectable({ providedIn: 'root' })
 export class PrediccionesService {
-  private readonly BASE_URL = 'http://127.0.0.1:5000/api';
+  private readonly BASE_URL = environment.apiUrl;
 
   constructor(private http: HttpClient) {}
 

--- a/tech-farming-frontend/src/environments/environment.prod.ts
+++ b/tech-farming-frontend/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
   supabaseUrl: 'https://efejsncxndycbgfyhvcv.supabase.co',
+  apiUrl: 'https://tech-farming-production.up.railway.app/api'
 };

--- a/tech-farming-frontend/src/environments/environment.ts
+++ b/tech-farming-frontend/src/environments/environment.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: false,
   supabaseUrl: 'https://efejsncxndycbgfyhvcv.supabase.co',
-  supabaseKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVmZWpzbmN4bmR5Y2JnZnlodmN2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDMwMzE0NjYsImV4cCI6MjA1ODYwNzQ2Nn0.CxHCTJkNFrT4BOZCnFTB3pylfxc-2w-mPtS5UXs7nHs'
+  supabaseKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVmZWpzbmN4bmR5Y2JnZnlodmN2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDMwMzE0NjYsImV4cCI6MjA1ODYwNzQ2Nn0.CxHCTJkNFrT4BOZCnFTB3pylfxc-2w-mPtS5UXs7nHs',
+  apiUrl: 'https://tech-farming-production.up.railway.app/api'
 };


### PR DESCRIPTION
## Summary
- point PrediccionesService to production API using environment file
- add `apiUrl` key to Angular environments
- rebuild frontend to ensure compilation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68681fcec574832a9cc61a11f448be60