### PR TITLE
Fix missing greenhouse check before loading historial

### DIFF
--- a/tech-farming-frontend/src/app/sensores/components/sensor-view-modal.component.ts
+++ b/tech-farming-frontend/src/app/sensores/components/sensor-view-modal.component.ts
@@ -212,6 +212,12 @@ export class SensorViewModalComponent implements OnInit, OnDestroy {
     this.series = [];
     this.stats = [];
 
+    if (!this.sensor.invernadero) {
+      alert('⚠️ Este sensor no está asignado a un invernadero.');
+      this.loading = false;
+      return;
+    }
+
     const calls = this.sensor.parametros.map(p =>
       this.tsSvc.getHistorial({
         invernaderoId: this.sensor.invernadero!.id,


### PR DESCRIPTION
## Summary
- handle undefined sensor.invernadero in `sensor-view-modal` before calling historial API
- run Angular build to verify compilation

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868284102e4832aa0d2d70b41718796